### PR TITLE
feat(governance): implement WP-00 contract registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
             fi
           done < <(git log --no-merges --format='%H%x09%s' "$range")
 
+      - name: Contract registry checks
+        run: |
+          lua -e 'package.path="./lua/?.lua;./lua/?/init.lua;"..package.path; assert(require("jig.spec.requirements").self_check())'
+          rg -n "MUST|SHOULD|MAY" docs/contract.jig.nvim.md
+
       - name: Formatting check
         run: stylua --check --config-path .stylua.toml $(rg --files lua -g '*.lua')
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,15 @@ NVIM_APPNAME=jig-safe nvim
 ```bash
 pattern='(nvim[-_]workbench|nvim(workbench)|nvim[-]2026|nvim(2026)|[N]vimWorkbench|[D]istroHealth|:[D]istro|distro[-]safe|distro[.])'
 rg -n "$pattern" . && exit 1 || true
+lua -e 'package.path="./lua/?.lua;./lua/?/init.lua;"..package.path; assert(require("jig.spec.requirements").self_check())'
+rg -n "MUST|SHOULD|MAY" docs/contract.jig.nvim.md
 nvim --headless -u ./init.lua '+lua print("jig-smoke")' '+qa'
 nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
 ```
 
 ## Documentation
 - `docs/install.jig.nvim.md`
+- `docs/contract.jig.nvim.md`
 - `docs/keymaps.jig.nvim.md`
 - `docs/architecture.jig.nvim.md`
 - `docs/maintenance.jig.nvim.md`

--- a/docs/architecture.jig.nvim.md
+++ b/docs/architecture.jig.nvim.md
@@ -1,6 +1,7 @@
 # architecture.jig.nvim.md
 
 ## Modules
+- `spec/requirements.lua`: machine-readable contract registry + self-check.
 - `core/options.lua`: editor defaults, font detection, loader setup.
 - `core/keymaps.lua`: keymap registry (initial baseline).
 - `core/autocmd.lua`: diagnostics/yank UX behaviors.
@@ -19,3 +20,4 @@
 - Native API alignment with Neovim 0.11+.
 - ASCII fallback for iconography.
 - PR-only + linear-history governance on `main`.
+- Optional extensions (including agent modules) must be removable without breaking core startup.

--- a/docs/contract.jig.nvim.md
+++ b/docs/contract.jig.nvim.md
@@ -1,0 +1,38 @@
+# contract.jig.nvim.md
+
+This document is the normative contract for Jig runtime behavior.
+`MUST`, `SHOULD`, and `MAY` are interpreted as RFC keywords.
+
+## Section 0: Scope
+- `S0-R01` MUST provide a portable, maintainable Neovim configuration system.
+- `S0-R02` MUST NOT force a single workflow ideology.
+
+## Section 1: Compatibility and Portability
+- `S1-R01` MUST enforce minimum Neovim version with deterministic diagnostics.
+- `S1-R02` SHOULD support profile isolation via `NVIM_APPNAME`.
+
+## Section 2: Installation, Updates, Reproducibility
+- `S2-R01` MUST keep plugin lifecycle operations explicit.
+- `S2-R02` MUST NOT auto-install plugins on startup by default.
+
+## Section 3: Observability and Troubleshooting
+- `S3-R01` MUST provide a doctor/health entrypoint with actionable output.
+- `S3-R02` SHOULD provide safe-mode startup with optional modules disabled.
+
+## Section 4: External Dependencies and Tooling
+- `S4-R01` MUST detect missing providers/binaries and provide remediation guidance.
+
+## Section 5: Performance and Initialization Discipline
+- `S5-R01` MUST avoid unnecessary startup side effects and eager heavy work.
+
+## Section 6: UX Defaults and Documentation
+- `S6-R01` MUST document default commands and keymaps.
+
+## Section 7: Security Posture
+- `S7-R01` MUST NOT execute startup network operations without explicit user action.
+
+## Section 8: Architecture Requirements
+- `S8-R01` MUST preserve modular boundaries and user-overridable behavior.
+
+## Section 9: Optional Extensions
+- `S9-R01` MAY provide agent integration as an optional removable module.

--- a/docs/maintenance.jig.nvim.md
+++ b/docs/maintenance.jig.nvim.md
@@ -3,6 +3,7 @@
 ## Release channels
 - `stable`: pinned plugin updates after CI pass.
 - `edge`: faster updates for compatibility validation.
+- Startup side-effect policy: do not auto-install or auto-update plugins/toolchains.
 
 ## Update process
 1. Update lockfile in branch.

--- a/docs/stability.jig.nvim.md
+++ b/docs/stability.jig.nvim.md
@@ -5,6 +5,7 @@
 - Optional channel: `edge`
 - No direct pushes to `main`; pull request flow only.
 - Linear history required on `main`.
+- Startup policy: no implicit plugin/tool install, update, or network mutation.
 
 ## Update Rules
 1. Update lockfile on feature branch.

--- a/lua/jig/spec/requirements.lua
+++ b/lua/jig/spec/requirements.lua
@@ -1,0 +1,196 @@
+local M = {}
+
+M.registry = {
+  {
+    id = "S0-R01",
+    section = 0,
+    level = "MUST",
+    text = "Jig must provide a portable, maintainable Neovim configuration system.",
+    owner = "core.bootstrap",
+    verification = "nvim --headless -u ./init.lua '+qa'",
+    falsifier = "startup requires machine-local manual patching or undocumented steps",
+  },
+  {
+    id = "S0-R02",
+    section = 0,
+    level = "MUST_NOT",
+    text = "Jig must not force a single workflow ideology.",
+    owner = "core.bootstrap",
+    verification = "docs/contract.jig.nvim.md references optional modules and defaults",
+    falsifier = "core startup hard-requires optional workflow modules",
+  },
+  {
+    id = "S1-R01",
+    section = 1,
+    level = "MUST",
+    text = "Jig must enforce a minimum supported Neovim version with deterministic diagnostics.",
+    owner = "core.bootstrap",
+    verification = "nvim --headless -u ./init.lua '+lua print(vim.g.jig_boot_ok)' '+qa'",
+    falsifier = "unsupported Neovim version reaches plugin initialization path",
+  },
+  {
+    id = "S1-R02",
+    section = 1,
+    level = "SHOULD",
+    text = "Jig should support isolated profiles via NVIM_APPNAME.",
+    owner = "core.bootstrap",
+    verification = "NVIM_APPNAME=jig nvim --headless -u ./init.lua '+qa'",
+    falsifier = "profile data/state collide across different NVIM_APPNAME values",
+  },
+  {
+    id = "S2-R01",
+    section = 2,
+    level = "MUST",
+    text = "Plugin install/update/restore operations must be explicit.",
+    owner = "core.lazy",
+    verification = "docs/maintenance.jig.nvim.md documents explicit plugin lifecycle commands",
+    falsifier = "startup triggers install/update without explicit user command",
+  },
+  {
+    id = "S2-R02",
+    section = 2,
+    level = "MUST_NOT",
+    text = "Startup must not auto-install plugins by default.",
+    owner = "core.lazy",
+    verification = "lazy bootstrap path returns guidance instead of cloning on startup",
+    falsifier = "cold startup executes git clone/fetch as implicit side effect",
+  },
+  {
+    id = "S3-R01",
+    section = 3,
+    level = "MUST",
+    text = "Jig must provide a doctor entrypoint for actionable troubleshooting.",
+    owner = "core.health",
+    verification = "nvim --headless -u ./init.lua '+checkhealth jig' '+qa'",
+    falsifier = "health checks report failures without actionable next step",
+  },
+  {
+    id = "S3-R02",
+    section = 3,
+    level = "SHOULD",
+    text = "Jig should provide a safe-mode startup entrypoint.",
+    owner = "core.bootstrap",
+    verification = "NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+qa'",
+    falsifier = "safe profile loads optional modules that are expected to be disabled",
+  },
+  {
+    id = "S4-R01",
+    section = 4,
+    level = "MUST",
+    text = "Missing providers and binaries must be surfaced with guidance.",
+    owner = "core.health",
+    verification = "nvim --headless -u ./init.lua '+checkhealth jig' '+qa'",
+    falsifier = "missing provider is silent or causes non-actionable crash",
+  },
+  {
+    id = "S5-R01",
+    section = 5,
+    level = "MUST",
+    text = "Startup must avoid heavy eager work and unnecessary side effects.",
+    owner = "core.lazy",
+    verification = "nvim --startuptime /tmp/jig.startup.log -u ./init.lua '+qa'",
+    falsifier = "core startup path performs eager network or large module loading without need",
+  },
+  {
+    id = "S6-R01",
+    section = 6,
+    level = "MUST",
+    text = "Default commands and keymaps must be documented and discoverable.",
+    owner = "docs.keymaps",
+    verification = "rg -n \"Jig\" docs/keymaps.jig.nvim.md",
+    falsifier = "default command/keymap exists with no documentation entry",
+  },
+  {
+    id = "S7-R01",
+    section = 7,
+    level = "MUST",
+    text = "Startup must not execute network operations by default.",
+    owner = "core.lazy",
+    verification = "core lazy bootstrap policy emits guidance and does not auto-clone",
+    falsifier = "startup path performs remote fetch/clone without explicit consent",
+  },
+  {
+    id = "S8-R01",
+    section = 8,
+    level = "MUST",
+    text = "Jig must remain modular and allow user overrides without core patching.",
+    owner = "core.bootstrap",
+    verification = "lua/jig paths are layered (core, plugins) and documented in docs/architecture.jig.nvim.md",
+    falsifier = "core behavior can only be changed by editing internal module files",
+  },
+  {
+    id = "S9-R01",
+    section = 9,
+    level = "MAY",
+    text = "Agent integrations are optional and removable extensions.",
+    owner = "agent.optional",
+    verification = "docs/architecture.jig.nvim.md marks agent path as optional extension",
+    falsifier = "core startup fails when optional agent module is absent",
+  },
+}
+
+local required_fields = {
+  "id",
+  "section",
+  "level",
+  "text",
+  "owner",
+  "verification",
+  "falsifier",
+}
+
+local function as_string(value)
+  if type(value) == "string" then
+    return value
+  end
+  return tostring(value)
+end
+
+function M.validate()
+  local errors = {}
+  local seen_ids = {}
+  local covered_sections = {}
+
+  for index, entry in ipairs(M.registry) do
+    for _, key in ipairs(required_fields) do
+      local value = entry[key]
+      if value == nil or as_string(value) == "" then
+        table.insert(errors, string.format("entry %d missing required field '%s'", index, key))
+      end
+    end
+
+    if type(entry.id) == "string" and entry.id ~= "" then
+      if seen_ids[entry.id] then
+        table.insert(errors, string.format("duplicate requirement id '%s'", entry.id))
+      end
+      seen_ids[entry.id] = true
+    end
+
+    if type(entry.section) ~= "number" or entry.section < 0 or entry.section > 9 then
+      table.insert(
+        errors,
+        string.format("entry %d has invalid section '%s'", index, as_string(entry.section))
+      )
+    else
+      covered_sections[entry.section] = true
+    end
+  end
+
+  for section = 0, 9 do
+    if not covered_sections[section] then
+      table.insert(errors, string.format("missing requirement coverage for section %d", section))
+    end
+  end
+
+  return #errors == 0, errors
+end
+
+function M.self_check()
+  local ok, errors = M.validate()
+  if ok then
+    return true
+  end
+  error("requirements registry validation failed:\n- " .. table.concat(errors, "\n- "))
+end
+
+return M


### PR DESCRIPTION
## Why
- Problem statement: WP-00 requires a machine-readable requirement registry with explicit verification/falsifier ownership and governance policy that constrains startup side effects.
- User impact: contributors and maintainers need deterministic checks before committing behavior claims.

## What
- Summary of change:
- Added machine-readable registry: `lua/jig/spec/requirements.lua`.
- Added normative contract surface with RFC keywords: `docs/contract.jig.nvim.md`.
- Added CI gate for registry validation + keyword presence in contract doc.
- Updated architecture/stability/maintenance/README docs to reference the contract and startup side-effect policy.

## Roadmap Linkage
- Work package(s): WP-00
- Requirement IDs: `S0-R01`, `S0-R02`, `S1-R01`, `S1-R02`, `S2-R01`, `S2-R02`, `S3-R01`, `S3-R02`, `S4-R01`, `S5-R01`, `S6-R01`, `S7-R01`, `S8-R01`, `S9-R01`

## Mode Declaration
- Mode: `Settle`
- Reason: adds enforceable contract artifacts + CI checks.

## Evidence
- [x] local smoke (`nvim --headless -u ./init.lua '+qa'`)
- [x] local health (`nvim --headless -u ./init.lua '+checkhealth jig' '+qa'`)
- [ ] CI checks pass
- Commands + output summary:
- `nvim --headless -u ./init.lua '+qa'` passed.
- `nvim --headless -u ./init.lua '+checkhealth jig' '+qa'` passed.
- `rg -n "MUST|SHOULD|MAY" docs/contract.jig.nvim.md` returned normative requirement lines for sections 0-9.
- `nvim --headless -u NONE '+set rtp+=/home/ismail-el-korchi/Documents/Projects/nvim-workbench.dev' '+lua require("jig.spec.requirements").self_check()' '+qa'` passed.

## Failure Modes and Residual Risk
1. Failure mode: registry drifts from runtime behavior while file shape remains valid.
- Discriminating check: link future WP requirement IDs to concrete runtime tests in CI lanes.
2. Failure mode: contract doc changes but registry IDs are not updated.
- Discriminating check: extend CI with contract-id cross-reference check (follow-up WP).

Residual risk:
- Current validation checks structural completeness and section coverage, not semantic equivalence between requirement text and implementation.

## Rollback Plan
- Revert command(s): `git revert 86fd8da`
- Rollback notes: removes registry/doc/CI additions and restores previous governance baseline.

## Docs and Security Impact
- Docs changed: `README.md`, `docs/contract.jig.nvim.md`, `docs/architecture.jig.nvim.md`, `docs/stability.jig.nvim.md`, `docs/maintenance.jig.nvim.md`.
- Network/exec/filesystem/policy impact: no new runtime network behavior; adds CI-time contract validation only.
