### PR TITLE
feat(plugins): implement WP-02 plugin lifecycle and rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,10 @@ jobs:
         run: |
           nvim --headless -u ./init.lua '+lua print("jig-smoke")' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.g.jig_profile=="default")' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginInstall")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginUpdate")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginRestore")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginRollback")==2)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.g.jig_profile=="safe")' '+qa'
 
       - name: Startup side-effect policy

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ NVIM_APPNAME=jig-safe nvim
 
 ## Commands
 - `:JigPluginBootstrap` install `lazy.nvim` explicitly.
+- `:JigPluginInstall` sync/install plugins.
+- `:JigPluginUpdate` preview (`Lazy check`) then apply update with explicit confirm.
+- `:JigPluginRestore` restore plugin state from `lazy-lock.json`.
+- `:JigPluginRollback` restore previous lockfile backup + `Lazy restore`.
 - `:JigChannel stable|edge` set update channel metadata.
 
 ## Profiles
@@ -64,6 +68,7 @@ nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
 - `docs/contract.jig.nvim.md`
 - `docs/keymaps.jig.nvim.md`
 - `docs/architecture.jig.nvim.md`
+- `docs/plugin-manager.jig.nvim.md`
 - `docs/maintenance.jig.nvim.md`
 - `docs/stability.jig.nvim.md`
 - `docs/compatibility.jig.nvim.md`

--- a/docs/architecture.jig.nvim.md
+++ b/docs/architecture.jig.nvim.md
@@ -7,6 +7,7 @@
 - `core/keymaps.lua`: keymap registry (initial baseline).
 - `core/autocmd.lua`: diagnostics/yank UX behaviors.
 - `core/lazy.lua`: plugin bootstrap and channel command.
+- `core/plugin_state.lua`: install/update/restore/rollback lifecycle commands.
 - `core/health.lua`: health provider used by `:checkhealth jig`.
 
 ## Plugin Layers

--- a/docs/maintenance.jig.nvim.md
+++ b/docs/maintenance.jig.nvim.md
@@ -6,10 +6,18 @@
 - Startup side-effect policy: do not auto-install or auto-update plugins/toolchains.
 
 ## Update process
-1. Update lockfile in branch.
-2. Run startup + health smoke tests.
-3. Validate cmdline (`:`), completion, diagnostics, and picker flows.
-4. Merge via pull request only.
+1. Ensure plugin manager exists (`:JigPluginBootstrap` if missing).
+2. Run `:JigPluginUpdate` and confirm apply explicitly.
+3. Validate startup + health smoke tests.
+4. Validate cmdline (`:`), completion, diagnostics, and picker flows.
+5. Commit lockfile changes in branch.
+6. Merge via pull request only.
+
+## Plugin lifecycle commands
+- Install/sync: `:JigPluginInstall`
+- Update (transactional confirm): `:JigPluginUpdate`
+- Restore from lockfile: `:JigPluginRestore`
+- Roll back using previous lockfile backup: `:JigPluginRollback`
 
 ## Regression checklist
 - Startup succeeds in headless mode.

--- a/docs/plugin-manager.jig.nvim.md
+++ b/docs/plugin-manager.jig.nvim.md
@@ -1,0 +1,33 @@
+# plugin-manager.jig.nvim.md
+
+## Backend Compatibility
+- Primary backend: `lazy.nvim`.
+- Fallback strategy: if `lazy.nvim` is absent, startup remains functional and provides explicit bootstrap command:
+  - `:JigPluginBootstrap`
+
+## Lock and Restore Policy
+- Lockfile path: `lazy-lock.json` under config root.
+- Rollback backup path: `${stdpath("state")}/jig/lazy-lock.previous.json`.
+- Startup policy: no implicit install/update/network mutation.
+
+## Commands
+- `:JigPluginInstall`
+  - sync/install plugins from the current spec/lock state.
+- `:JigPluginUpdate`
+  - runs `Lazy check`, requires explicit confirm, then applies update.
+  - saves a rollback backup when lockfile exists.
+- `:JigPluginRestore`
+  - restores plugins from `lazy-lock.json`.
+- `:JigPluginRollback`
+  - restores backup lockfile then runs `Lazy restore`.
+
+## Rollback Path
+1. Run `:JigPluginRollback`.
+2. Verify startup:
+```bash
+nvim --headless -u ./init.lua '+qa'
+```
+3. Run health:
+```vim
+:checkhealth jig
+```

--- a/docs/troubleshooting.jig.nvim.md
+++ b/docs/troubleshooting.jig.nvim.md
@@ -28,7 +28,7 @@ Expected default: `false`.
 ```
 3. Restart Neovim and run:
 ```vim
-:Lazy sync
+:JigPluginInstall
 ```
 
 ## Icon Rendering Problems

--- a/lua/jig/core/lazy.lua
+++ b/lua/jig/core/lazy.lua
@@ -1,4 +1,5 @@
 local brand = require("jig.core.brand")
+local plugin_state = require("jig.core.plugin_state")
 
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 local lazy_available = vim.uv.fs_stat(lazypath) ~= nil
@@ -35,6 +36,11 @@ vim.api.nvim_create_user_command(brand.command("PluginBootstrap"), function()
   install_lazy()
 end, {
   desc = "Install lazy.nvim explicitly (no startup auto-install)",
+})
+
+plugin_state.register({
+  lazypath = lazypath,
+  bootstrap_command = brand.command("PluginBootstrap"),
 })
 
 if not lazy_available then

--- a/lua/jig/core/plugin_state.lua
+++ b/lua/jig/core/plugin_state.lua
@@ -1,0 +1,145 @@
+local brand = require("jig.core.brand")
+
+local M = {}
+
+local state = {
+  lazypath = nil,
+  bootstrap_command = brand.command("PluginBootstrap"),
+}
+
+local function lockfile_path()
+  return vim.fn.stdpath("config") .. "/lazy-lock.json"
+end
+
+local function rollback_path()
+  return vim.fn.stdpath("state") .. "/jig/lazy-lock.previous.json"
+end
+
+local function file_exists(path)
+  return vim.uv.fs_stat(path) ~= nil
+end
+
+local function copy_file(src, dst)
+  local content = vim.fn.readfile(src, "b")
+  vim.fn.mkdir(vim.fn.fnamemodify(dst, ":h"), "p")
+  vim.fn.writefile(content, dst, "b")
+end
+
+local function lazy_available()
+  return state.lazypath ~= nil and file_exists(state.lazypath)
+end
+
+local function require_lazy_or_prompt()
+  if lazy_available() then
+    return true
+  end
+
+  vim.notify(
+    "lazy.nvim not installed. Run :" .. state.bootstrap_command .. " first.",
+    vim.log.levels.WARN
+  )
+  return false
+end
+
+local function backup_lockfile()
+  local lockfile = lockfile_path()
+  if not file_exists(lockfile) then
+    return false
+  end
+  copy_file(lockfile, rollback_path())
+  return true
+end
+
+function M.install()
+  if not lazy_available() then
+    vim.cmd(state.bootstrap_command)
+    return
+  end
+  vim.cmd("Lazy sync")
+end
+
+function M.restore()
+  if not require_lazy_or_prompt() then
+    return
+  end
+  vim.cmd("Lazy restore")
+end
+
+function M.update()
+  if not require_lazy_or_prompt() then
+    return
+  end
+
+  vim.cmd("Lazy check")
+  local choice = vim.fn.confirm("Apply plugin updates?", "&Apply\n&Cancel", 2)
+  if choice ~= 1 then
+    vim.notify("Plugin update cancelled", vim.log.levels.INFO)
+    return
+  end
+
+  if backup_lockfile() then
+    vim.notify("Lockfile backup saved to " .. rollback_path(), vim.log.levels.INFO)
+  else
+    vim.notify("No lazy-lock.json found; continuing update without backup", vim.log.levels.WARN)
+  end
+
+  vim.cmd("Lazy update")
+end
+
+function M.rollback()
+  if not require_lazy_or_prompt() then
+    return
+  end
+
+  local backup = rollback_path()
+  local lockfile = lockfile_path()
+  if not file_exists(backup) then
+    vim.notify("No rollback lockfile found at " .. backup, vim.log.levels.ERROR)
+    return
+  end
+
+  copy_file(backup, lockfile)
+  vim.notify("Rollback lockfile restored to " .. lockfile, vim.log.levels.INFO)
+  vim.cmd("Lazy restore")
+end
+
+function M.register(opts)
+  opts = opts or {}
+  if opts.lazypath then
+    state.lazypath = opts.lazypath
+  end
+  if opts.bootstrap_command and opts.bootstrap_command ~= "" then
+    state.bootstrap_command = opts.bootstrap_command
+  end
+
+  local commands = {
+    {
+      name = brand.command("PluginInstall"),
+      fn = M.install,
+      desc = "Install/sync plugins from lock state",
+    },
+    {
+      name = brand.command("PluginUpdate"),
+      fn = M.update,
+      desc = "Preview then apply plugin updates (explicit confirm)",
+    },
+    {
+      name = brand.command("PluginRestore"),
+      fn = M.restore,
+      desc = "Restore plugins from lazy-lock.json",
+    },
+    {
+      name = brand.command("PluginRollback"),
+      fn = M.rollback,
+      desc = "Restore previous lockfile backup and run Lazy restore",
+    },
+  }
+
+  for _, command in ipairs(commands) do
+    -- boundary: allow-vim-api
+    -- Justification: command registration is a Neovim host boundary operation.
+    vim.api.nvim_create_user_command(command.name, command.fn, { desc = command.desc })
+  end
+end
+
+return M

--- a/lua/jig/spec/requirements.lua
+++ b/lua/jig/spec/requirements.lua
@@ -43,7 +43,7 @@ M.registry = {
     level = "MUST",
     text = "Plugin install/update/restore operations must be explicit.",
     owner = "core.lazy",
-    verification = "docs/maintenance.jig.nvim.md documents explicit plugin lifecycle commands",
+    verification = ":JigPluginInstall, :JigPluginUpdate, :JigPluginRestore, :JigPluginRollback",
     falsifier = "startup triggers install/update without explicit user command",
   },
   {


### PR DESCRIPTION
## Why
- Problem statement: WP-02 requires explicit plugin lifecycle commands, lock/rollback mechanics, and no implicit startup mutation.
- User impact: update failures must be recoverable with one command, and updates must be explicit/confirmable.

## What
- Summary of change:
- Added `core/plugin_state.lua` with explicit commands:
  - `:JigPluginInstall`
  - `:JigPluginUpdate` (runs `Lazy check` + explicit confirm)
  - `:JigPluginRestore`
  - `:JigPluginRollback` (restores backup lockfile + `Lazy restore`)
- Integrated command registration into `core/lazy.lua`.
- Added lockfile backup path policy under `stdpath("state")/jig/lazy-lock.previous.json`.
- Added plugin manager lifecycle docs: `docs/plugin-manager.jig.nvim.md`.
- Updated CI smoke assertions for plugin lifecycle command presence.
- Updated maintenance/troubleshooting/README/architecture docs for explicit lifecycle and rollback path.

## Roadmap Linkage
- Work package(s): WP-02
- Requirement IDs: `S2-R01`, `S2-R02`, `S7-R01`

## Mode Declaration
- Mode: `Settle`
- Reason: implementation and verification checks for explicit plugin lifecycle behavior.

## Evidence
- [x] local smoke (`nvim --headless -u ./init.lua '+qa'`)
- [x] local health (`nvim --headless -u ./init.lua '+checkhealth jig' '+qa'`)
- [ ] CI checks pass
- Commands + output summary:
- `stylua --check --config-path .stylua.toml $(rg --files lua -g '*.lua')` passed.
- `nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginInstall")==2)' '+lua assert(vim.fn.exists(":JigPluginUpdate")==2)' '+lua assert(vim.fn.exists(":JigPluginRestore")==2)' '+lua assert(vim.fn.exists(":JigPluginRollback")==2)' '+qa'` passed.
- `tmp=$(mktemp -d); XDG_DATA_HOME="$tmp/data" XDG_STATE_HOME="$tmp/state" XDG_CACHE_HOME="$tmp/cache" NVIM_APPNAME=jig-ci nvim --headless -u ./init.lua '+qa'; test ! -d "$tmp/data/jig-ci/lazy/lazy.nvim"` passed.
- `nvim --headless -u ./init.lua '+checkhealth jig' '+qa'` passed.

## Failure Modes and Residual Risk
1. Failure mode: update command applies changes without explicit user confirmation.
- Discriminating check: implementation uses `vim.fn.confirm` gate before `Lazy update`.
2. Failure mode: rollback command cannot restore prior lock state.
- Discriminating check: update path writes backup lockfile and rollback command restores backup before `Lazy restore`.

Residual risk:
- `lazy-lock.json` semantic drift vs plugin API changes still depends on upstream plugin-manager behavior; CI assertions currently validate command/path behavior rather than full plugin graph replay.

## Rollback Plan
- Revert command(s): `git revert 4040f53`
- Rollback notes: removes lifecycle command layer and restores prior minimal lazy integration.

## Docs and Security Impact
- Docs changed: `README.md`, `docs/plugin-manager.jig.nvim.md`, `docs/maintenance.jig.nvim.md`, `docs/troubleshooting.jig.nvim.md`, `docs/architecture.jig.nvim.md`.
- Network/exec/filesystem/policy impact: update/install actions remain explicit user commands; startup still avoids implicit clone/update.
