### PR TITLE
feat(observability): deliver WP-03 doctor and recovery workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,10 @@ jobs:
         run: |
           nvim --headless -u ./init.lua '+lua print("jig-smoke")' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.g.jig_profile=="default")' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigHealth")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigVerboseMap")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigVerboseSet")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigBisectGuide")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginInstall")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginUpdate")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigPluginRestore")==2)' '+qa'
@@ -147,7 +151,7 @@ jobs:
           test ! -d "$tmp/data/jig-ci/lazy/lazy.nvim"
 
       - name: Health check
-        run: nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
+        run: nvim --headless -u ./init.lua '+JigHealth' '+qa'
 
   nightly-report:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ NVIM_APPNAME=jig-safe nvim
 ```
 
 ## Commands
+- `:JigHealth` run distro + provider health checks.
+- `:JigVerboseMap {lhs}` show keymap provenance.
+- `:JigVerboseSet {option}` show option provenance.
+- `:JigBisectGuide` print deterministic bisect guidance.
 - `:JigPluginBootstrap` install `lazy.nvim` explicitly.
 - `:JigPluginInstall` sync/install plugins.
 - `:JigPluginUpdate` preview (`Lazy check`) then apply update with explicit confirm.
@@ -69,6 +73,7 @@ nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
 - `docs/keymaps.jig.nvim.md`
 - `docs/architecture.jig.nvim.md`
 - `docs/plugin-manager.jig.nvim.md`
+- `docs/profiling.jig.nvim.md`
 - `docs/maintenance.jig.nvim.md`
 - `docs/stability.jig.nvim.md`
 - `docs/compatibility.jig.nvim.md`

--- a/docs/architecture.jig.nvim.md
+++ b/docs/architecture.jig.nvim.md
@@ -6,6 +6,7 @@
 - `core/options.lua`: editor defaults, font detection, loader setup.
 - `core/keymaps.lua`: keymap registry (initial baseline).
 - `core/autocmd.lua`: diagnostics/yank UX behaviors.
+- `core/doctor.lua`: health/provenance/bisect command entrypoints.
 - `core/lazy.lua`: plugin bootstrap and channel command.
 - `core/plugin_state.lua`: install/update/restore/rollback lifecycle commands.
 - `core/health.lua`: health provider used by `:checkhealth jig`.

--- a/docs/profiling.jig.nvim.md
+++ b/docs/profiling.jig.nvim.md
@@ -1,0 +1,34 @@
+# profiling.jig.nvim.md
+
+## Startup Profiling
+Use Neovim built-in startup timing:
+
+```bash
+nvim --startuptime /tmp/jig.startuptime.log -u ./init.lua '+qa'
+```
+
+Inspect the slowest entries:
+
+```bash
+tail -n 60 /tmp/jig.startuptime.log
+```
+
+## Compare Two Runs
+Run twice on clean startup and compare top entries:
+
+```bash
+nvim --startuptime /tmp/jig.a.log -u ./init.lua '+qa'
+nvim --startuptime /tmp/jig.b.log -u ./init.lua '+qa'
+```
+
+Focus on:
+- plugin init spikes
+- repeated provider checks
+- optional module load on safe profile (should be absent)
+
+## Recovery Profiling
+For recovery baseline:
+
+```bash
+NVIM_APPNAME=jig-safe nvim --startuptime /tmp/jig.safe.log -u ./init.lua '+qa'
+```

--- a/docs/troubleshooting.jig.nvim.md
+++ b/docs/troubleshooting.jig.nvim.md
@@ -3,6 +3,7 @@
 ## Run Health Check
 ```vim
 :checkhealth jig
+:JigHealth
 ```
 
 ## Cmdline Error On `:`
@@ -55,3 +56,26 @@ Expected default: `false`.
 rg --version
 ```
 2. Reopen Neovim and retry `<leader><leader>` and `<leader>/`.
+
+## Provenance Helpers
+- Keymap provenance:
+```vim
+:JigVerboseMap <leader>qq
+```
+- Option provenance:
+```vim
+:JigVerboseSet number
+```
+
+## Deterministic Bisect Workflow
+1. Start safe profile:
+```bash
+NVIM_APPNAME=jig-safe nvim
+```
+2. Re-enable optional modules in halves and restart each time.
+3. Keep the failing half; disable the passing half.
+4. Repeat until one module remains.
+5. Capture issue with:
+```vim
+:JigHealth
+```

--- a/lua/jig/core/doctor.lua
+++ b/lua/jig/core/doctor.lua
@@ -1,0 +1,59 @@
+local brand = require("jig.core.brand")
+
+local M = {}
+
+local function cmd_verbose_map(opts)
+  local lhs = opts.args
+  -- boundary: allow-vim-api
+  -- Justification: command execution must use Neovim command API for provenance helpers.
+  vim.api.nvim_cmd({
+    cmd = "verbose",
+    args = { "map", lhs },
+  }, {})
+end
+
+local function cmd_verbose_set(opts)
+  local option = opts.args
+  -- boundary: allow-vim-api
+  -- Justification: command execution must use Neovim command API for provenance helpers.
+  vim.api.nvim_cmd({
+    cmd = "verbose",
+    args = { "set", option .. "?" },
+  }, {})
+end
+
+local function cmd_health()
+  vim.cmd("checkhealth jig")
+  vim.cmd("checkhealth provider")
+end
+
+local function cmd_bisect_guide()
+  vim.notify(
+    "Bisect workflow: disable half modules, restart, repeat. See docs/troubleshooting.jig.nvim.md",
+    vim.log.levels.INFO
+  )
+end
+
+function M.setup()
+  -- boundary: allow-vim-api
+  -- Justification: user command registration is a Neovim host boundary operation.
+  vim.api.nvim_create_user_command(brand.command("Health"), cmd_health, {
+    desc = "Run Jig and provider health checks",
+  })
+
+  vim.api.nvim_create_user_command(brand.command("VerboseMap"), cmd_verbose_map, {
+    nargs = 1,
+    desc = "Show keymap provenance via :verbose map <lhs>",
+  })
+
+  vim.api.nvim_create_user_command(brand.command("VerboseSet"), cmd_verbose_set, {
+    nargs = 1,
+    desc = "Show option provenance via :verbose set <option>?",
+  })
+
+  vim.api.nvim_create_user_command(brand.command("BisectGuide"), cmd_bisect_guide, {
+    desc = "Show deterministic bisect guidance",
+  })
+end
+
+return M

--- a/lua/jig/core/health.lua
+++ b/lua/jig/core/health.lua
@@ -13,19 +13,39 @@ function M.check()
   if vim.fn.executable("rg") == 1 then
     vim.health.ok("ripgrep detected")
   else
-    vim.health.warn("ripgrep not found; grep picker performance/features reduced")
+    vim.health.warn("ripgrep not found; install with: sudo apt install ripgrep")
   end
 
   if vim.fn.executable("git") == 1 then
     vim.health.ok("git detected")
   else
-    vim.health.error("git not found")
+    vim.health.error("git not found; install with: sudo apt install git")
+  end
+
+  if vim.fn.executable("fd") == 1 then
+    vim.health.ok("fd detected")
+  else
+    vim.health.warn(
+      "fd not found; finder fallback is slower. install with: sudo apt install fd-find"
+    )
   end
 
   if vim.fn.has("clipboard") == 1 then
     vim.health.ok("clipboard provider available")
   else
-    vim.health.warn("clipboard provider missing")
+    vim.health.warn("clipboard provider missing; run :checkhealth provider for setup details")
+  end
+
+  if vim.fn.has("python3") == 1 then
+    vim.health.ok("python3 provider available")
+  else
+    vim.health.warn("python3 provider missing; run :checkhealth provider")
+  end
+
+  if vim.fn.has("nodejs") == 1 then
+    vim.health.ok("node provider available")
+  else
+    vim.health.warn("node provider missing; run :checkhealth provider")
   end
 
   if vim.g.have_nerd_font then

--- a/lua/jig/init.lua
+++ b/lua/jig/init.lua
@@ -7,6 +7,7 @@ end
 require("jig.core.options")
 require("jig.core.keymaps")
 require("jig.core.autocmd")
+require("jig.core.doctor").setup()
 
 if vim.g.jig_safe_profile then
   return

--- a/lua/jig/spec/requirements.lua
+++ b/lua/jig/spec/requirements.lua
@@ -61,7 +61,7 @@ M.registry = {
     level = "MUST",
     text = "Jig must provide a doctor entrypoint for actionable troubleshooting.",
     owner = "core.health",
-    verification = "nvim --headless -u ./init.lua '+checkhealth jig' '+qa'",
+    verification = ":JigHealth",
     falsifier = "health checks report failures without actionable next step",
   },
   {


### PR DESCRIPTION
## Why
- Problem statement: WP-03 requires a single doctor entrypoint, actionable provider/binary diagnostics, provenance helpers, and deterministic profiling/bisect guidance.
- User impact: troubleshooting must be command-driven and reproducible when startup/cmdline/plugin failures occur.

## What
- Summary of change:
- Added `core/doctor.lua` and registered commands:
  - `:JigHealth`
  - `:JigVerboseMap`
  - `:JigVerboseSet`
  - `:JigBisectGuide`
- Wired doctor setup into core startup (`lua/jig/init.lua`).
- Enhanced health output with actionable remediation text for missing `git`, `rg`, `fd`, clipboard, python, and node providers.
- Added startup profiling runbook: `docs/profiling.jig.nvim.md`.
- Extended troubleshooting docs with provenance and deterministic bisect workflow.
- Added CI smoke assertions for doctor/provenance command registration and switched health lane to `:JigHealth`.

## Roadmap Linkage
- Work package(s): WP-03
- Requirement IDs: `S3-R01`, `S3-R02`, `S4-R01`

## Mode Declaration
- Mode: `Settle`
- Reason: this introduces runtime behavior and CI verification for observability/recovery paths.

## Evidence
- [x] local smoke (`nvim --headless -u ./init.lua '+qa'`)
- [x] local health (`nvim --headless -u ./init.lua '+checkhealth jig' '+qa'`)
- [ ] CI checks pass
- Commands + output summary:
- `nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigHealth")==2)' '+lua assert(vim.fn.exists(":JigVerboseMap")==2)' '+lua assert(vim.fn.exists(":JigVerboseSet")==2)' '+lua assert(vim.fn.exists(":JigBisectGuide")==2)' '+qa'` passed.
- `NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.g.jig_profile=="safe")' '+qa'` passed.
- `tmp=$(mktemp -d); XDG_DATA_HOME="$tmp/data" XDG_STATE_HOME="$tmp/state" XDG_CACHE_HOME="$tmp/cache" NVIM_APPNAME=jig-ci nvim --headless -u ./init.lua '+qa'; test ! -d "$tmp/data/jig-ci/lazy/lazy.nvim"` passed.
- `nvim --headless -u ./init.lua '+JigHealth' '+qa'` passed.

## Failure Modes and Residual Risk
1. Failure mode: doctor command exists but does not include provider-level checks.
- Discriminating check: `:JigHealth` runs both `checkhealth jig` and `checkhealth provider`.
2. Failure mode: provenance helpers execute unsafely or become non-deterministic.
- Discriminating check: commands use `vim.api.nvim_cmd` with explicit arg list.

Residual risk:
- Profiling and bisect runbooks are currently doc-driven; automated differential profiling thresholds are deferred to later CI fabric packages.

## Rollback Plan
- Revert command(s): `git revert c04939a`
- Rollback notes: removes doctor/provenance commands and reverts health lane back to direct `:checkhealth jig`.

## Docs and Security Impact
- Docs changed: `README.md`, `docs/troubleshooting.jig.nvim.md`, `docs/profiling.jig.nvim.md`, `docs/architecture.jig.nvim.md`.
- Network/exec/filesystem/policy impact: no new startup network behavior; adds command-level introspection only.
