### PR TITLE
test(ci): WP-12 CI + test fabric + failure injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
             exit 1
           fi
 
+      - name: Hidden Unicode gate
+        run: tests/check_hidden_unicode.sh
+
       - name: Naming checks
         run: |
           set -euo pipefail
@@ -201,6 +204,7 @@ jobs:
           rg -n '"root-determinism"' tests/nav/snapshots/latest-headless.json
           rg -n '"latency-budget-smoke"' tests/nav/snapshots/latest-headless.json
           rg -n '"candidate-cap-guardrail"' tests/nav/snapshots/latest-headless.json
+          rg -n '"large-fixture-tier-guardrail"' tests/nav/snapshots/latest-headless.json
 
       - name: Keymap harness snapshot checks
         run: |
@@ -210,6 +214,13 @@ jobs:
           rg -n '"runtime-forbidden-not-mapped"' tests/keymaps/snapshots/latest-headless.json
           rg -n '"runtime-registry-subset"' tests/keymaps/snapshots/latest-headless.json
           rg -n '"docs-sync-gate"' tests/keymaps/snapshots/latest-headless.json
+
+      - name: Completion harness snapshot checks
+        run: |
+          tests/completion/run_harness.sh
+          test -f tests/completion/snapshots/latest-headless.json
+          rg -n '"completion-policy-defaults"' tests/completion/snapshots/latest-headless.json
+          rg -n '"completion-fallback-smoke"' tests/completion/snapshots/latest-headless.json
 
       - name: Keymap docs sync gate
         run: |
@@ -242,6 +253,7 @@ jobs:
           rg -n '"task-cancel-resume"' tests/agent/snapshots/latest-headless.json
           rg -n '"mcp-failure-injection"' tests/agent/snapshots/latest-headless.json
           rg -n '"acp-bridge-hook"' tests/agent/snapshots/latest-headless.json
+          rg -n '"context-ledger-token-budget"' tests/agent/snapshots/latest-headless.json
           rg -n '"safe-profile-isolation"' tests/agent/snapshots/latest-headless.json
 
       - name: Security harness snapshot checks
@@ -263,6 +275,41 @@ jobs:
           rg -n '"shell-detection-and-argv-strategy"' tests/platform/snapshots/latest-headless.json
           rg -n '"clipboard-non-fatal"' tests/platform/snapshots/latest-headless.json
           rg -n '"root-detection-normalized-input"' tests/platform/snapshots/latest-headless.json
+
+      - name: Pending harness snapshot checks
+        run: |
+          tests/pending/run_harness.sh
+          test -f tests/pending/snapshots/latest-headless.json
+          rg -n '"agent:approval-notification-visible"' tests/pending/snapshots/latest-headless.json
+          rg -n '"agent:patch-diff-hunk-apply"' tests/pending/snapshots/latest-headless.json
+          rg -n '"status":"pending"' tests/pending/snapshots/latest-headless.json
+
+      - name: Quarantine and pending allowlist gates
+        run: |
+          nvim --headless -u NONE -l tests/check_quarantine.lua
+          nvim --headless -u NONE -l tests/check_pending.lua
+
+      - name: Quarantine growth policy (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          tests/check_quarantine_growth.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+
+      - name: Performance harness snapshot checks
+        run: |
+          tests/perf/run_harness.sh
+          test -f tests/perf/snapshots/latest-headless.json
+          rg -n '"time-to-first-diagnostic"' tests/perf/snapshots/latest-headless.json
+          rg -n '"time-to-first-completion-menu"' tests/perf/snapshots/latest-headless.json
+          rg -n '"time-to-first-picker-results"' tests/perf/snapshots/latest-headless.json
+          rg -n '"metrics"' tests/perf/snapshots/latest-headless.json
+
+      - name: Upload perf snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-snapshot-${{ matrix.nvim }}
+          path: tests/perf/snapshots/latest-headless.json
 
       - name: Cross-platform runner smoke
         run: |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ nvim --headless -u ./init.lua '+lua assert(vim.g.jig_profile=="default")' '+qa'
 NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.g.jig_profile=="safe")' '+qa'
 nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
 nvim --headless -u NONE -l tests/run_harness.lua -- --all
+tests/check_hidden_unicode.sh
+nvim --headless -u NONE -l tests/check_quarantine.lua
+nvim --headless -u NONE -l tests/check_pending.lua
+tests/perf/run_harness.sh
 ```
 
 ## Documentation
@@ -120,6 +124,7 @@ nvim --headless -u NONE -l tests/run_harness.lua -- --all
 - `docs/agents.jig.nvim.md`
 - `docs/security.jig.nvim.md`
 - `docs/platform.jig.nvim.md`
+- `docs/testing.jig.nvim.md`
 - `docs/ui-foundation.jig.nvim.md`
 - `docs/ui-testing.jig.nvim.md`
 - `docs/maintenance.jig.nvim.md`
@@ -131,6 +136,7 @@ nvim --headless -u NONE -l tests/run_harness.lua -- --all
 - `doc/jig-agents.txt` (`:help jig-agents`)
 - `doc/jig-security.txt` (`:help jig-security`)
 - `doc/jig-platform.txt` (`:help jig-platform`)
+- `doc/jig-testing.txt` (`:help jig-testing`)
 
 ## License
 MIT

--- a/doc/jig-testing.txt
+++ b/doc/jig-testing.txt
@@ -1,0 +1,73 @@
+*jig-testing* jig.nvim testing
+
+Jig testing fabric is a deterministic headless suite framework introduced in WP-12.
+
+==============================================================================
+OVERVIEW                                                        *jig-testing-overview*
+
+Main runner:
+  nvim --headless -u NONE -l tests/run_harness.lua -- --all
+
+Run a suite:
+  nvim --headless -u NONE -l tests/run_harness.lua -- --suite <name>
+
+Key policy checks:
+  nvim --headless -u NONE -l tests/check_quarantine.lua
+  nvim --headless -u NONE -l tests/check_pending.lua
+  tests/check_hidden_unicode.sh
+
+==============================================================================
+SNAPSHOTS                                                      *jig-testing-snapshots*
+
+Each suite writes:
+  tests/<suite>/snapshots/latest-headless.json
+
+Snapshot fields include:
+  harness, generated_at, cases, summary.
+
+Timing-sensitive tests MUST declare label "timing-sensitive" and use retries.
+
+==============================================================================
+QUARANTINE                                                    *jig-testing-quarantine*
+
+Allowlist file:
+  tests/quarantine.json
+
+CI fails when:
+  - timing-sensitive case is missing from allowlist
+  - allowlist contains stale entries
+
+PRs that grow the quarantine list must include:
+  [quarantine-justification]
+
+==============================================================================
+PENDING TESTS                                                   *jig-testing-pending*
+
+Allowlist file:
+  tests/pending_tests.json
+
+Use pending tests only for roadmap-blocked checks. CI fails when pending entries
+are unallowlisted or stale.
+
+==============================================================================
+PERFORMANCE                                                       *jig-testing-perf*
+
+Perf harness:
+  tests/perf/run_harness.sh
+
+Budgets:
+  tests/perf/budgets.json
+
+Metrics:
+  - first diagnostic event
+  - first completion fallback confirmation
+  - first picker result batch under fixture tiers
+
+==============================================================================
+FIXTURE GENERATOR                                              *jig-testing-fixtures*
+
+Tiered nav fixture generator:
+  nvim --headless -u NONE -l tests/fixtures/generate_nav_fixture.lua -- --tier large
+
+==============================================================================
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/docs/architecture.jig.nvim.md
+++ b/docs/architecture.jig.nvim.md
@@ -71,6 +71,13 @@
 - `plugins/git.lua`: git signs and hunk state.
 - `plugins/syntax.lua`: treesitter highlighting/indent.
 
+## Test Fabric Modules
+- `tests/run_harness.lua`: unified headless suite runner (`--suite <name>`).
+- `tests/check_quarantine.lua`: timing-sensitive quarantine allowlist gate.
+- `tests/check_pending.lua`: pending-test allowlist gate for roadmap-blocked checks.
+- `lua/jig/tests/fixtures/nav_repo.lua`: deterministic tiered repository generator for nav/perf probes.
+- `lua/jig/tests/perf/harness.lua`: deterministic perf probes and extreme-regression budgets.
+
 ## Policy
 - Stability-first defaults.
 - Native API alignment with Neovim 0.11+.

--- a/docs/roadmap/EXECUTION_BOARD.md
+++ b/docs/roadmap/EXECUTION_BOARD.md
@@ -106,8 +106,15 @@ Updated at: `2026-02-21`
 - ADR(s): tbd
 
 ### WP-11: Cross-Platform Compatibility Matrix
-- Status: `in-progress`
+- Status: `done`
 - Depends on: `WP-10`
 - Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/15
-- PR(s): tbd
+- PR(s): https://github.com/Ismail-elkorchi/jig.nvim/pull/36
+- ADR(s): tbd
+
+### WP-12: CI, Test Fabric, and Failure Injection
+- Status: `in-progress`
+- Depends on: `WP-03`, `WP-11`
+- Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/16
+- PR(s): https://github.com/Ismail-elkorchi/jig.nvim/pull/TBD
 - ADR(s): tbd

--- a/docs/roadmap/WP-12-DELTA.md
+++ b/docs/roadmap/WP-12-DELTA.md
@@ -1,0 +1,21 @@
+# WP-12 Delta (Issue #16)
+
+## Already Done Before WP-12 Branch
+- Stable + previous-stable CI coverage exists in required lanes.
+- Nightly CI lane exists and is non-blocking.
+- Unified headless harness entrypoint exists: `tests/run_harness.lua`.
+- Existing suites already cover startup smoke, cmdline open/close, icon fallback, keymap conflicts, provider health, MCP failure basics, timeout/recovery basics.
+- Cross-platform compatibility matrix from WP-11 is already wired in CI.
+
+## Missing and Implemented in WP-12 Branch
+- Quarantine policy and enforcement for timing-sensitive tests.
+- Pending-test scaffolding and allowlist enforcement for WP-17-dependent tests.
+- Dedicated completion-fallback suite.
+- Deterministic perf probes beyond startup:
+  - first diagnostic
+  - first completion fallback confirmation
+  - first picker results across small/medium/large fixture tiers
+- Deterministic large-repo fixture generator (script + module; no bulk committed fixtures).
+- Hidden/bidirectional Unicode CI gate.
+- CI artifact publication for perf snapshots.
+- Documentation for running/maintaining the test fabric.

--- a/docs/testing.jig.nvim.md
+++ b/docs/testing.jig.nvim.md
@@ -1,0 +1,70 @@
+# testing.jig.nvim.md
+
+## Scope
+WP-12 defines Jig test fabric contracts for determinism, failure injection, and CI gating.
+
+## Local Commands
+- Run all default suites:
+  - `nvim --headless -u NONE -l tests/run_harness.lua -- --all`
+- Run one suite:
+  - `nvim --headless -u NONE -l tests/run_harness.lua -- --suite ui`
+- Run perf probes:
+  - `tests/perf/run_harness.sh`
+- Validate timing-sensitive quarantine policy:
+  - `nvim --headless -u NONE -l tests/check_quarantine.lua`
+- Validate pending-test allowlist policy:
+  - `nvim --headless -u NONE -l tests/check_pending.lua`
+- Validate hidden/bidi Unicode gate:
+  - `tests/check_hidden_unicode.sh`
+
+## Snapshot Contract
+Each suite writes `tests/<suite>/snapshots/latest-headless.json` with:
+- `harness`: suite contract identifier
+- `cases`: per-case status/details/labels
+- `summary`: pass/fail and pending aggregates
+
+Timing-sensitive cases MUST include:
+- `labels: ["timing-sensitive"]`
+- deterministic retry policy (`attempts`, fixed retry count, fixed delay)
+
+## Quarantine Policy
+- Allowlist file: `tests/quarantine.json`
+- CI fails if:
+  - a timing-sensitive case appears without allowlist entry
+  - an allowlist entry is stale
+- If allowlist grows in a PR, PR body MUST include `[quarantine-justification]`.
+
+## Pending Test Policy
+- Allowlist file: `tests/pending_tests.json`
+- Pending tests are limited to roadmap dependencies not implemented yet.
+- CI fails if:
+  - a pending case is not allowlisted
+  - allowlisted pending entries are stale
+
+Current pending set tracks WP-17-dependent surfaces:
+- approval visibility UI for pending actions
+- transactional patch/diff hunk accept/reject pipeline
+
+## Performance Probes
+Perf suite: `lua/jig/tests/perf/harness.lua`
+- `time-to-first-diagnostic`
+- `time-to-first-completion-menu` (headless fallback confirmation path)
+- `time-to-first-picker-results` across deterministic fixture tiers
+
+Budgets: `tests/perf/budgets.json`
+- thresholds are conservative and serve as extreme-regression gates
+- output snapshots are uploaded as CI artifacts
+
+## Deterministic Large-Repo Fixture
+Generator module: `lua/jig/tests/fixtures/nav_repo.lua`
+Generator script: `tests/fixtures/generate_nav_fixture.lua`
+- creates tiered fixture repos (`small`, `medium`, `large`)
+- no bulk generated file trees are committed
+
+## Adding a New Suite Safely
+1. Add suite module under `lua/jig/tests/<suite>/harness.lua`.
+2. Register suite in `tests/run_harness.lua`.
+3. Add snapshot directory + `.gitignore`.
+4. Add CI step with deterministic assertions.
+5. If timing-sensitive, add retry labels and quarantine entry.
+6. If dependency-blocked, add pending case + allowlist entry.

--- a/lua/jig/tests/completion/harness.lua
+++ b/lua/jig/tests/completion/harness.lua
@@ -1,0 +1,79 @@
+local fabric = require("jig.tests.fabric")
+
+local M = {}
+
+local function snapshot_path(opts)
+  return fabric.snapshot_path(
+    opts,
+    vim.fn.stdpath("state") .. "/jig/completion-harness-snapshot.json"
+  )
+end
+
+local function completion_spec()
+  local specs = require("jig.plugins.completion")
+  assert(type(specs) == "table" and #specs >= 1, "completion plugin spec missing")
+  local first = specs[1]
+  assert(type(first.opts) == "table", "completion opts missing")
+  return first.opts
+end
+
+local cases = {
+  {
+    id = "completion-policy-defaults",
+    run = function()
+      local opts = completion_spec()
+      assert(opts.fuzzy and opts.fuzzy.implementation == "lua", "lua fuzzy fallback required")
+      assert(
+        opts.cmdline and opts.cmdline.enabled == false,
+        "cmdline completion must stay disabled"
+      )
+      return {
+        fuzzy = opts.fuzzy.implementation,
+        cmdline_enabled = opts.cmdline.enabled,
+      }
+    end,
+  },
+  {
+    id = "completion-fallback-smoke",
+    run = function()
+      local candidates = {
+        "alpha",
+        "alpine",
+        "application",
+        "beta",
+        "gamma",
+      }
+      local started = vim.uv.hrtime()
+      local matched = vim.fn.matchfuzzy(candidates, "alp")
+      local elapsed_ms = math.floor((vim.uv.hrtime() - started) / 1000000)
+
+      assert(
+        type(matched) == "table" and #matched >= 1,
+        "fallback fuzzy completion returned no candidates"
+      )
+      assert(elapsed_ms <= 300, "fallback completion latency budget exceeded")
+
+      local ok_blink = pcall(require, "blink.cmp")
+      return {
+        elapsed_ms = elapsed_ms,
+        matched = #matched,
+        blink_loaded = ok_blink,
+      }
+    end,
+  },
+}
+
+function M.run(opts)
+  local report = fabric.run_cases(cases, {
+    harness = "headless-child-completion",
+  })
+
+  local path = snapshot_path(opts)
+  fabric.finalize(report, {
+    snapshot_path = path,
+    fail_label = "completion harness",
+  })
+  print("completion-harness snapshot written: " .. path)
+end
+
+return M

--- a/lua/jig/tests/fabric.lua
+++ b/lua/jig/tests/fabric.lua
@@ -1,0 +1,193 @@
+local M = {}
+
+local function includes(list, needle)
+  if type(list) ~= "table" then
+    return false
+  end
+  for _, item in ipairs(list) do
+    if item == needle then
+      return true
+    end
+  end
+  return false
+end
+
+function M.snapshot_path(opts, fallback)
+  if opts and type(opts.snapshot_path) == "string" and opts.snapshot_path ~= "" then
+    return opts.snapshot_path
+  end
+  return fallback
+end
+
+function M.write_snapshot(path, payload)
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  vim.fn.writefile({ vim.json.encode(payload) }, path)
+end
+
+function M.load_json(path)
+  if vim.fn.filereadable(path) ~= 1 then
+    return nil
+  end
+
+  local lines = vim.fn.readfile(path)
+  local ok, decoded = pcall(vim.json.decode, table.concat(lines, "\n"))
+  if not ok or type(decoded) ~= "table" then
+    return nil
+  end
+
+  return decoded
+end
+
+function M.retry_count(case, defaults)
+  local labels = case.labels or {}
+  if tonumber(case.retries) then
+    return math.max(1, math.floor(tonumber(case.retries)))
+  end
+
+  if includes(labels, "timing-sensitive") then
+    local value = tonumber(defaults and defaults.timing_sensitive_retries) or 3
+    return math.max(2, math.floor(value))
+  end
+
+  return 1
+end
+
+function M.retry_delay_ms(case, defaults)
+  if tonumber(case.retry_delay_ms) then
+    return math.max(0, math.floor(tonumber(case.retry_delay_ms)))
+  end
+
+  if includes(case.labels or {}, "timing-sensitive") then
+    return math.max(0, math.floor(tonumber(defaults and defaults.timing_sensitive_delay_ms) or 80))
+  end
+
+  return 0
+end
+
+local function run_case(case, defaults)
+  if case.pending == true then
+    return {
+      ok = true,
+      status = "pending",
+      attempts = 0,
+      labels = case.labels or {},
+      reason = tostring(case.pending_reason or "pending"),
+      details = {
+        pending = true,
+      },
+    }
+  end
+
+  local attempts = M.retry_count(case, defaults)
+  local retry_delay_ms = M.retry_delay_ms(case, defaults)
+
+  local last_details = {}
+  for attempt = 1, attempts do
+    local ok, passed, details = pcall(case.run)
+    if ok and passed then
+      return {
+        ok = true,
+        status = "passed",
+        attempts = attempt,
+        labels = case.labels or {},
+        retry_delay_ms = retry_delay_ms,
+        details = details or {},
+      }
+    end
+
+    last_details = details or { error = passed }
+    if attempt < attempts and retry_delay_ms > 0 then
+      vim.wait(retry_delay_ms)
+    end
+  end
+
+  return {
+    ok = false,
+    status = "failed",
+    attempts = attempts,
+    labels = case.labels or {},
+    retry_delay_ms = retry_delay_ms,
+    details = last_details,
+  }
+end
+
+function M.run_cases(cases, opts)
+  opts = opts or {}
+  local report = {
+    harness = tostring(opts.harness or "headless-child-harness"),
+    generated_at = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+    cases = {},
+  }
+
+  local failed = {}
+  local pending = {}
+
+  for _, case in ipairs(cases) do
+    local result = run_case(case, opts.retry_defaults)
+    report.cases[case.id] = {
+      ok = result.ok,
+      status = result.status,
+      labels = result.labels,
+      attempts = result.attempts,
+      retry_delay_ms = result.retry_delay_ms,
+      pending_reason = result.reason,
+      details = result.details,
+    }
+
+    if result.status == "failed" then
+      failed[#failed + 1] = case.id
+    elseif result.status == "pending" then
+      pending[#pending + 1] = case.id
+    end
+  end
+
+  report.summary = {
+    passed = #failed == 0,
+    failed_cases = failed,
+    pending_cases = pending,
+    failed_count = #failed,
+    pending_count = #pending,
+  }
+
+  return report
+end
+
+function M.finalize(report, opts)
+  opts = opts or {}
+  M.write_snapshot(opts.snapshot_path, report)
+
+  if report.summary.failed_count > 0 then
+    error(
+      string.format(
+        "%s failed: %s",
+        tostring(opts.fail_label or "harness"),
+        table.concat(report.summary.failed_cases, ", ")
+      )
+    )
+  end
+
+  if opts.fail_on_pending == true and report.summary.pending_count > 0 then
+    error(
+      string.format(
+        "%s contains pending tests: %s",
+        tostring(opts.fail_label or "harness"),
+        table.concat(report.summary.pending_cases, ", ")
+      )
+    )
+  end
+end
+
+function M.repo_root(depth)
+  if type(_G.__jig_repo_root) == "string" and _G.__jig_repo_root ~= "" then
+    return _G.__jig_repo_root
+  end
+  local source = debug.getinfo(1, "S").source:sub(2)
+  local hops = depth or 2
+  local modifier = ":p"
+  for _ = 1, hops do
+    modifier = modifier .. ":h"
+  end
+  return vim.fn.fnamemodify(source, modifier)
+end
+
+return M

--- a/lua/jig/tests/fixtures/nav_repo.lua
+++ b/lua/jig/tests/fixtures/nav_repo.lua
@@ -1,0 +1,104 @@
+local path = require("jig.platform.path")
+
+local M = {}
+
+local SPECS = {
+  small = {
+    dirs = 10,
+    files_per_dir = 12,
+    marker = "tier-small",
+  },
+  medium = {
+    dirs = 20,
+    files_per_dir = 36,
+    marker = "tier-medium",
+  },
+  large = {
+    dirs = 28,
+    files_per_dir = 60,
+    marker = "tier-large",
+  },
+}
+
+local function write(pathname, lines)
+  vim.fn.mkdir(vim.fn.fnamemodify(pathname, ":h"), "p")
+  vim.fn.writefile(lines, pathname)
+end
+
+local function tier_root(base, tier)
+  return path.join(base, tier)
+end
+
+local function ensure_markers(root, marker)
+  write(path.join(root, "jig.root"), { marker })
+  write(path.join(root, ".git", "HEAD"), { "ref: refs/heads/main" })
+  write(path.join(root, ".gitignore"), {
+    "build/",
+    "node_modules/",
+    "*.tmp",
+  })
+end
+
+local function create_files(root, tier, spec)
+  local count = 0
+  for d = 1, spec.dirs do
+    local dirname = string.format("pkg_%02d", d)
+    local dir = path.join(root, "src", dirname)
+    vim.fn.mkdir(dir, "p")
+
+    for i = 1, spec.files_per_dir do
+      count = count + 1
+      local filename = string.format("mod_%04d.lua", i)
+      local filepath = path.join(dir, filename)
+      write(filepath, {
+        string.format("-- fixture tier=%s dir=%s index=%d", tier, dirname, i),
+        string.format("return %d", count),
+      })
+    end
+  end
+
+  write(path.join(root, "README.md"), {
+    "# Navigation Fixture",
+    "",
+    "tier: " .. tier,
+    "files: " .. tostring(count),
+  })
+
+  return count
+end
+
+function M.specs()
+  return vim.deepcopy(SPECS)
+end
+
+function M.generate(opts)
+  opts = opts or {}
+  local tier = tostring(opts.tier or "small")
+  local spec = SPECS[tier]
+  assert(spec ~= nil, "unknown tier: " .. tier)
+
+  local base = opts.base_dir or (vim.fn.stdpath("state") .. "/jig/nav-fixtures")
+  local root = tier_root(base, tier)
+
+  if vim.fn.isdirectory(root) == 1 then
+    return {
+      root = root,
+      tier = tier,
+      files = tonumber(vim.fn.len(vim.fn.globpath(root, "**/*.lua", false, true))) or 0,
+      reused = true,
+    }
+  end
+
+  vim.fn.mkdir(root, "p")
+  ensure_markers(root, spec.marker)
+  local files = create_files(root, tier, spec)
+
+  return {
+    root = root,
+    tier = tier,
+    files = files,
+    reused = false,
+  }
+end
+
+return M

--- a/lua/jig/tests/pending/harness.lua
+++ b/lua/jig/tests/pending/harness.lua
@@ -1,0 +1,125 @@
+local fabric = require("jig.tests.fabric")
+
+local M = {}
+
+local function repo_root()
+  if type(_G.__jig_repo_root) == "string" and _G.__jig_repo_root ~= "" then
+    return _G.__jig_repo_root
+  end
+  local source = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(source, ":p:h:h:h:h:h")
+end
+
+local function snapshot_path(opts)
+  return fabric.snapshot_path(opts, vim.fn.stdpath("state") .. "/jig/pending-harness-snapshot.json")
+end
+
+local function allowlist_path()
+  return repo_root() .. "/tests/pending_tests.json"
+end
+
+local function load_allowlist()
+  local payload = fabric.load_json(allowlist_path()) or {}
+  local allowed = payload.allowed_pending or {}
+  if vim.islist(allowed) then
+    local map = {}
+    for _, id in ipairs(allowed) do
+      map[tostring(id)] = ""
+    end
+    return map
+  end
+  if type(allowed) == "table" then
+    return allowed
+  end
+  return {}
+end
+
+local function has_feature(command_name, module_name)
+  if
+    type(command_name) == "string"
+    and command_name ~= ""
+    and vim.fn.exists(":" .. command_name) == 2
+  then
+    return true
+  end
+  if type(module_name) == "string" and module_name ~= "" then
+    local ok = pcall(require, module_name)
+    if ok then
+      return true
+    end
+  end
+  return false
+end
+
+local probes = {
+  {
+    id = "agent:approval-notification-visible",
+    labels = { "future-work" },
+    pending_reason = "WP-17 approval queue UI not implemented",
+    implemented = function()
+      return has_feature("JigAgentApprovals", "jig.agent.approvals")
+    end,
+  },
+  {
+    id = "agent:patch-diff-hunk-apply",
+    labels = { "future-work" },
+    pending_reason = "WP-17 transactional patch/diff pipeline not implemented",
+    implemented = function()
+      return has_feature("JigPatchReview", "jig.agent.patch")
+    end,
+  },
+}
+
+function M.run(opts)
+  local allowlist = load_allowlist()
+
+  local report = {
+    harness = "headless-child-pending",
+    generated_at = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+    cases = {},
+  }
+
+  local pending = {}
+  for _, probe in ipairs(probes) do
+    local implemented = probe.implemented()
+    local status = implemented and "implemented" or "pending"
+
+    if not implemented then
+      assert(allowlist[probe.id] ~= nil, "pending test not in allowlist: " .. probe.id)
+      pending[#pending + 1] = probe.id
+    end
+
+    report.cases[probe.id] = {
+      ok = true,
+      status = status,
+      labels = probe.labels,
+      pending_reason = implemented and "" or probe.pending_reason,
+      details = {
+        implemented = implemented,
+      },
+    }
+  end
+
+  local pending_set = {}
+  for _, id in ipairs(pending) do
+    pending_set[id] = true
+  end
+  for id, _ in pairs(allowlist) do
+    assert(pending_set[id] == true, "stale pending allowlist entry: " .. id)
+  end
+
+  table.sort(pending)
+  report.summary = {
+    passed = true,
+    failed_cases = {},
+    pending_cases = pending,
+    failed_count = 0,
+    pending_count = #pending,
+  }
+
+  local path = snapshot_path(opts)
+  fabric.write_snapshot(path, report)
+  print("pending-harness snapshot written: " .. path)
+end
+
+return M

--- a/lua/jig/tests/perf/harness.lua
+++ b/lua/jig/tests/perf/harness.lua
@@ -1,0 +1,197 @@
+local backend = require("jig.nav.backend")
+local fabric = require("jig.tests.fabric")
+local nav_fixture = require("jig.tests.fixtures.nav_repo")
+
+local M = {}
+
+local function repo_root()
+  if type(_G.__jig_repo_root) == "string" and _G.__jig_repo_root ~= "" then
+    return _G.__jig_repo_root
+  end
+  local source = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(source, ":p:h:h:h:h:h")
+end
+
+local function snapshot_path(opts)
+  return fabric.snapshot_path(opts, vim.fn.stdpath("state") .. "/jig/perf-harness-snapshot.json")
+end
+
+local function budget_path()
+  return repo_root() .. "/tests/perf/budgets.json"
+end
+
+local function load_budgets()
+  local decoded = fabric.load_json(budget_path())
+  assert(type(decoded) == "table", "perf budgets JSON is invalid")
+  return decoded
+end
+
+local function elapsed_ms(started)
+  return math.floor((vim.uv.hrtime() - started) / 1000000)
+end
+
+local function ensure_under(value, limit, label)
+  assert(type(value) == "number", label .. " missing")
+  assert(type(limit) == "number", label .. " limit missing")
+  assert(value <= limit, string.format("%s exceeded (%d > %d)", label, value, limit))
+end
+
+local function probe_first_diagnostic(limit)
+  local bufnr = vim.api.nvim_create_buf(true, true)
+  local ns = vim.api.nvim_create_namespace("jig.tests.perf")
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "local x = 1" })
+
+  local observed = nil
+  local started = vim.uv.hrtime()
+
+  local augroup = vim.api.nvim_create_augroup("JigPerfDiagnostic", { clear = true })
+  vim.api.nvim_create_autocmd("DiagnosticChanged", {
+    group = augroup,
+    buffer = bufnr,
+    once = true,
+    callback = function()
+      observed = elapsed_ms(started)
+    end,
+  })
+
+  vim.defer_fn(function()
+    vim.diagnostic.set(ns, bufnr, {
+      {
+        lnum = 0,
+        col = 0,
+        end_lnum = 0,
+        end_col = 5,
+        message = "perf diagnostic",
+        severity = vim.diagnostic.severity.WARN,
+      },
+    })
+  end, 20)
+
+  local done = vim.wait(2000, function()
+    return observed ~= nil
+  end, 10)
+
+  vim.api.nvim_del_augroup_by_id(augroup)
+  vim.diagnostic.reset(ns, bufnr)
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+
+  assert(done == true and observed ~= nil, "first diagnostic event not observed")
+  ensure_under(observed, limit, "first-diagnostic-ms")
+  return observed
+end
+
+local function probe_first_completion(limit)
+  local words = {}
+  for i = 1, 2000 do
+    words[#words + 1] = string.format("token_%04d", i)
+  end
+
+  local started = vim.uv.hrtime()
+  local matches = vim.fn.matchfuzzy(words, "token_19")
+  local observed = elapsed_ms(started)
+
+  assert(type(matches) == "table" and #matches > 0, "completion fallback returned no matches")
+  ensure_under(observed, limit, "first-completion-ms")
+  return observed
+end
+
+local function probe_picker_tier(tier, limit)
+  local generated = nav_fixture.generate({
+    tier = tier,
+    base_dir = repo_root() .. "/tests/fixtures/generated/nav_perf",
+  })
+
+  local started = vim.uv.hrtime()
+  local result = backend.files({ root = generated.root }, {
+    select = false,
+    candidate_cap = 100,
+    cap = 100,
+    ignore_globs = { "node_modules/**", "build/**" },
+  })
+  local observed = elapsed_ms(started)
+
+  assert(type(result) == "table", "picker result missing")
+  assert(type(result.count) == "number" and result.count > 0, "picker returned no candidates")
+  assert(result.count <= 100, "picker exceeded cap")
+  ensure_under(observed, limit, "picker-first-ms:" .. tier)
+
+  return {
+    elapsed_ms = observed,
+    count = result.count,
+    fixture_files = generated.files,
+    fixture_reused = generated.reused,
+  }
+end
+
+local function probe_all()
+  local budgets = load_budgets()
+  local picker_limits = budgets.picker_first_ms or {}
+
+  local diagnostics_ms = probe_first_diagnostic(tonumber(budgets.diagnostic_first_ms) or 800)
+  local completion_ms = probe_first_completion(tonumber(budgets.completion_first_ms) or 400)
+
+  local picker = {
+    small = probe_picker_tier("small", tonumber(picker_limits.small) or 800),
+    medium = probe_picker_tier("medium", tonumber(picker_limits.medium) or 1600),
+    large = probe_picker_tier("large", tonumber(picker_limits.large) or 2600),
+  }
+
+  return {
+    budgets = budgets,
+    probes = {
+      time_to_first_diagnostic_ms = diagnostics_ms,
+      time_to_first_completion_ms = completion_ms,
+      time_to_first_picker_ms = picker,
+    },
+  }
+end
+
+function M.run(opts)
+  local cached = probe_all()
+
+  local report = fabric.run_cases({
+    {
+      id = "time-to-first-diagnostic",
+      run = function()
+        return {
+          diagnostic_ms = cached.probes.time_to_first_diagnostic_ms,
+          budget_ms = cached.budgets.diagnostic_first_ms,
+        }
+      end,
+    },
+    {
+      id = "time-to-first-completion-menu",
+      run = function()
+        return {
+          completion_ms = cached.probes.time_to_first_completion_ms,
+          mode = "fallback-confirmation",
+          budget_ms = cached.budgets.completion_first_ms,
+        }
+      end,
+    },
+    {
+      id = "time-to-first-picker-results",
+      run = function()
+        return {
+          picker = cached.probes.time_to_first_picker_ms,
+          budgets = cached.budgets.picker_first_ms,
+        }
+      end,
+    },
+  }, {
+    harness = "headless-child-perf",
+  })
+
+  report.metrics = cached.probes
+  report.budgets = cached.budgets
+
+  local path = snapshot_path(opts)
+  fabric.finalize(report, {
+    snapshot_path = path,
+    fail_label = "perf harness",
+  })
+  print("perf-harness snapshot written: " .. path)
+end
+
+return M

--- a/tests/check_hidden_unicode.sh
+++ b/tests/check_hidden_unicode.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+pattern='[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200B}\x{200C}\x{200D}\x{FEFF}]'
+if rg -n --pcre2 "$pattern" . ; then
+  echo "hidden/bidi unicode characters detected"
+  exit 1
+fi
+
+echo "hidden/bidi unicode gate passed"

--- a/tests/check_pending.lua
+++ b/tests/check_pending.lua
@@ -1,0 +1,77 @@
+local function repo_root()
+  local source = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(source, ":p:h:h")
+end
+
+local ROOT = repo_root()
+
+local function read_json(path)
+  local lines = vim.fn.readfile(path)
+  local ok, decoded = pcall(vim.json.decode, table.concat(lines, "\n"))
+  if not ok or type(decoded) ~= "table" then
+    error("invalid json: " .. path)
+  end
+  return decoded
+end
+
+local function to_set(input)
+  local set = {}
+  if type(input) ~= "table" then
+    return set
+  end
+  for key, _ in pairs(input) do
+    set[tostring(key)] = true
+  end
+  return set
+end
+
+local function is_pending(entry)
+  if type(entry) ~= "table" then
+    return false
+  end
+  if entry.status == "pending" then
+    return true
+  end
+  if type(entry.details) == "table" and entry.details.status == "pending" then
+    return true
+  end
+  return false
+end
+
+local function main()
+  local allow = read_json(ROOT .. "/tests/pending_tests.json")
+  local allow_set = to_set(allow.allowed_pending)
+
+  local snapshot = read_json(ROOT .. "/tests/pending/snapshots/latest-headless.json")
+  local discovered = {}
+
+  for case_id, entry in pairs(snapshot.cases or {}) do
+    if is_pending(entry) then
+      discovered[case_id] = true
+      if not allow_set[case_id] then
+        error("pending case not allowlisted: " .. case_id)
+      end
+    end
+  end
+
+  for case_id, _ in pairs(allow_set) do
+    if not discovered[case_id] then
+      error("stale pending allowlist entry: " .. case_id)
+    end
+  end
+
+  local keys = vim.tbl_keys(discovered)
+  table.sort(keys)
+  print("pending allowlist validated")
+  for _, key in ipairs(keys) do
+    print(" - " .. key)
+  end
+end
+
+local ok, err = pcall(main)
+if not ok then
+  vim.api.nvim_err_writeln(tostring(err))
+  vim.cmd("cquit 1")
+end
+
+vim.cmd("qa")

--- a/tests/check_quarantine.lua
+++ b/tests/check_quarantine.lua
@@ -1,0 +1,90 @@
+local function repo_root()
+  local source = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(source, ":p:h:h")
+end
+
+local ROOT = repo_root()
+
+local function read_json(path)
+  local lines = vim.fn.readfile(path)
+  local ok, decoded = pcall(vim.json.decode, table.concat(lines, "\n"))
+  if not ok or type(decoded) ~= "table" then
+    error("invalid json: " .. path)
+  end
+  return decoded
+end
+
+local function to_set(input)
+  local set = {}
+  if type(input) ~= "table" then
+    return set
+  end
+  for key, _ in pairs(input) do
+    set[tostring(key)] = true
+  end
+  return set
+end
+
+local function has_label(labels, needle)
+  if type(labels) ~= "table" then
+    return false
+  end
+  for _, label in ipairs(labels) do
+    if label == needle then
+      return true
+    end
+  end
+  return false
+end
+
+local function find_snapshots()
+  local paths = vim.fn.globpath(ROOT .. "/tests", "*/snapshots/latest-headless.json", false, true)
+  table.sort(paths)
+  return paths
+end
+
+local function suite_name(snapshot_path)
+  local parent = vim.fn.fnamemodify(snapshot_path, ":h:h:t")
+  return parent
+end
+
+local function main()
+  local quarantine = read_json(ROOT .. "/tests/quarantine.json")
+  local allow = to_set(quarantine.timing_sensitive_allowlist)
+
+  local discovered = {}
+  for _, snapshot in ipairs(find_snapshots()) do
+    local suite = suite_name(snapshot)
+    local payload = read_json(snapshot)
+    for case_id, info in pairs(payload.cases or {}) do
+      if has_label(info.labels, "timing-sensitive") then
+        local key = suite .. ":" .. case_id
+        discovered[key] = true
+        if not allow[key] then
+          error("timing-sensitive case not allowlisted: " .. key)
+        end
+      end
+    end
+  end
+
+  for key, _ in pairs(allow) do
+    if not discovered[key] then
+      error("stale timing-sensitive allowlist entry: " .. key)
+    end
+  end
+
+  local ordered = vim.tbl_keys(discovered)
+  table.sort(ordered)
+  print("quarantine allowlist validated")
+  for _, key in ipairs(ordered) do
+    print(" - " .. key)
+  end
+end
+
+local ok, err = pcall(main)
+if not ok then
+  vim.api.nvim_err_writeln(tostring(err))
+  vim.cmd("cquit 1")
+end
+
+vim.cmd("qa")

--- a/tests/check_quarantine_growth.sh
+++ b/tests/check_quarantine_growth.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <base-sha> <head-sha>"
+  exit 1
+fi
+
+base_sha="$1"
+head_sha="$2"
+
+if ! git diff --quiet "$base_sha..$head_sha" -- tests/quarantine.json; then
+  added_entries="$(git diff --unified=0 "$base_sha..$head_sha" -- tests/quarantine.json | rg '^\+\s*"[^"]+":' || true)"
+  if [[ -n "$added_entries" ]]; then
+    if [[ "${PR_BODY:-}" != *"[quarantine-justification]"* ]]; then
+      echo "quarantine allowlist grew; add [quarantine-justification] note in PR body"
+      echo "$added_entries"
+      exit 1
+    fi
+  fi
+fi
+
+echo "quarantine growth check passed"

--- a/tests/completion/run_harness.sh
+++ b/tests/completion/run_harness.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+nvim --headless -u NONE -l tests/run_harness.lua -- --suite completion
+
+echo "Completion harness passed. Snapshot: ${repo_root}/tests/completion/snapshots/latest-headless.json"

--- a/tests/completion/snapshots/.gitignore
+++ b/tests/completion/snapshots/.gitignore
@@ -1,0 +1,1 @@
+latest-headless.json

--- a/tests/fixtures/generate_nav_fixture.lua
+++ b/tests/fixtures/generate_nav_fixture.lua
@@ -1,0 +1,49 @@
+local function repo_root()
+  local source = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(source, ":p:h:h")
+end
+
+local ROOT = repo_root()
+package.path = string.format("%s/lua/?.lua;%s/lua/?/init.lua;", ROOT, ROOT) .. package.path
+vim.opt.rtp:prepend(ROOT)
+
+local nav_fixture = require("jig.tests.fixtures.nav_repo")
+
+local function parse(argv)
+  local out = {
+    tier = "small",
+    base = ROOT .. "/tests/fixtures/generated",
+  }
+
+  local index = 1
+  while index <= #argv do
+    local token = argv[index]
+    if token == "--tier" then
+      out.tier = tostring(argv[index + 1] or out.tier)
+      index = index + 2
+    elseif token == "--base" then
+      out.base = tostring(argv[index + 1] or out.base)
+      index = index + 2
+    else
+      index = index + 1
+    end
+  end
+
+  return out
+end
+
+local ok, err = pcall(function()
+  local opts = parse(arg or {})
+  local generated = nav_fixture.generate({
+    tier = opts.tier,
+    base_dir = opts.base,
+  })
+  print(vim.json.encode(generated))
+end)
+
+if not ok then
+  vim.api.nvim_err_writeln(tostring(err))
+  vim.cmd("cquit 1")
+end
+
+vim.cmd("qa")

--- a/tests/pending/run_harness.sh
+++ b/tests/pending/run_harness.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+nvim --headless -u NONE -l tests/run_harness.lua -- --suite pending
+
+echo "Pending harness passed. Snapshot: ${repo_root}/tests/pending/snapshots/latest-headless.json"

--- a/tests/pending/snapshots/.gitignore
+++ b/tests/pending/snapshots/.gitignore
@@ -1,0 +1,1 @@
+latest-headless.json

--- a/tests/pending_tests.json
+++ b/tests/pending_tests.json
@@ -1,0 +1,6 @@
+{
+  "allowed_pending": {
+    "agent:approval-notification-visible": "WP-17 approval queue UI not implemented yet.",
+    "agent:patch-diff-hunk-apply": "WP-17 transactional patch/diff pipeline not implemented yet."
+  }
+}

--- a/tests/perf/budgets.json
+++ b/tests/perf/budgets.json
@@ -1,0 +1,10 @@
+{
+  "diagnostic_first_ms": 1600,
+  "completion_first_ms": 400,
+  "picker_first_ms": {
+    "small": 800,
+    "medium": 1600,
+    "large": 2600
+  },
+  "extreme_regression_factor": 2.0
+}

--- a/tests/perf/run_harness.sh
+++ b/tests/perf/run_harness.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+nvim --headless -u NONE -l tests/run_harness.lua -- --suite perf
+
+echo "Perf harness passed. Snapshot: ${repo_root}/tests/perf/snapshots/latest-headless.json"

--- a/tests/perf/snapshots/.gitignore
+++ b/tests/perf/snapshots/.gitignore
@@ -1,0 +1,1 @@
+latest-headless.json

--- a/tests/quarantine.json
+++ b/tests/quarantine.json
@@ -1,0 +1,7 @@
+{
+  "timing_sensitive_allowlist": {
+    "ui:cmdline-open-close": "cmdline open/close check depends on event-loop scheduling.",
+    "tools:capture-concurrency-guard": "async shell capture queue ordering can vary by host shell startup latency.",
+    "agent:task-cancel-resume": "task cancel/resume transitions depend on scheduler timing."
+  }
+}

--- a/tests/run_harness.lua
+++ b/tests/run_harness.lua
@@ -109,6 +109,10 @@ local SUITES = {
     module = "jig.tests.keymaps.harness",
     snapshot = join(ROOT, "tests/keymaps/snapshots/latest-headless.json"),
   },
+  completion = {
+    module = "jig.tests.completion.harness",
+    snapshot = join(ROOT, "tests/completion/snapshots/latest-headless.json"),
+  },
   nav = {
     module = "jig.tests.nav.harness",
     snapshot = join(ROOT, "tests/nav/snapshots/latest-headless.json"),
@@ -129,6 +133,14 @@ local SUITES = {
     module = "jig.tests.security.harness",
     snapshot = join(ROOT, "tests/security/snapshots/latest-headless.json"),
   },
+  perf = {
+    module = "jig.tests.perf.harness",
+    snapshot = join(ROOT, "tests/perf/snapshots/latest-headless.json"),
+  },
+  pending = {
+    module = "jig.tests.pending.harness",
+    snapshot = join(ROOT, "tests/pending/snapshots/latest-headless.json"),
+  },
   platform = {
     module = "jig.tests.platform.harness",
     snapshot = join(ROOT, "tests/platform/snapshots/latest-headless.json"),
@@ -136,7 +148,7 @@ local SUITES = {
 }
 
 local DEFAULT_SUITES =
-  { "startup", "cmdline", "ui", "keymaps", "nav", "tools", "security", "platform" }
+  { "startup", "cmdline", "ui", "keymaps", "completion", "nav", "tools", "security", "platform" }
 
 local function resolve_suites(parsed)
   if parsed.all == true or #parsed.suites == 0 then


### PR DESCRIPTION
## Why
- Problem statement: WP-12 (#16) requires CI/test-fabric hardening so regressions are blocked by deterministic gates instead of manual review.
- User impact: startup/cmdline/nav/tools/agent/security regressions become visible and reproducible; release lanes block high-severity failures.

## What
- Summary of change:
  - Added WP-12 test-fabric controls: quarantine policy, pending-test policy, hidden Unicode gate, perf probes, deterministic fixture generation, and new harness suites.
  - Extended CI required lanes with completion/perf/pending checks and policy gates.
  - Added testing documentation and execution-board updates.

## Roadmap Linkage
- Work package(s): `WP-12: CI, Test Fabric, and Failure Injection`
- Requirement IDs: Issue #16 deliverables + acceptance/falsifier checks.
- Closes #16

## Mode Declaration
- Mode: `Settle`
- Reason: this PR ships enforceable CI/test gates with deterministic verification outputs.

## Deliverable Mapping (WP-12)
- [x] CI lanes stable + previous stable + nightly non-blocking
  - Files: `.github/workflows/ci.yml`
- [x] UI harness contract + retry/quarantine policy
  - Files: `lua/jig/tests/ui/harness.lua`, `lua/jig/tests/tools/harness.lua`, `lua/jig/tests/agent/harness.lua`, `tests/quarantine.json`, `tests/check_quarantine.lua`, `tests/check_quarantine_growth.sh`
- [x] Performance gates beyond startup
  - Files: `lua/jig/tests/perf/harness.lua`, `tests/perf/budgets.json`, `tests/perf/run_harness.sh`, `lua/jig/tests/fixtures/nav_repo.lua`, `tests/fixtures/generate_nav_fixture.lua`
- [x] Expanded suites list (startup/cmdline/completion/icon/keymaps/provider/MCP/timeout/agent pending+ledger)
  - Files: `tests/run_harness.lua`, `lua/jig/tests/completion/harness.lua`, `lua/jig/tests/agent/harness.lua`, `lua/jig/tests/pending/harness.lua`, existing suite modules
- [x] Pending-test mechanism for WP-17 dependencies
  - Files: `tests/pending_tests.json`, `tests/check_pending.lua`, `lua/jig/tests/pending/harness.lua`
- [x] Deterministic large-repo navigation fixtures
  - Files: `lua/jig/tests/fixtures/nav_repo.lua`, `tests/fixtures/generate_nav_fixture.lua`, `lua/jig/tests/nav/harness.lua`
- [x] Bidi/hidden Unicode gate
  - Files: `tests/check_hidden_unicode.sh`, `.github/workflows/ci.yml`
- [x] Documentation
  - Files: `docs/testing.jig.nvim.md`, `doc/jig-testing.txt`, `docs/roadmap/WP-12-DELTA.md`, `README.md`, `docs/architecture.jig.nvim.md`

## Evidence
- [x] local smoke (`nvim --headless -u ./init.lua '+qa'`)
- [x] local health (`nvim --headless -u ./init.lua '+checkhealth jig' '+qa'`)
- [ ] CI checks pass (pending)
- Commands + output summary:
  - `stylua --check --config-path .stylua.toml $(rg --files lua tests -g '*.lua')`
    - pass (no diff)
  - `nvim --headless -u ./init.lua '+checkhealth jig' '+qa'`
    - pass (`Running healthchecks...`)
  - `tests/check_hidden_unicode.sh`
    - pass (`hidden/bidi unicode gate passed`)
  - `tests/ui/run_harness.sh && tests/keymaps/run_harness.sh && tests/completion/run_harness.sh && tests/nav/run_harness.sh && tests/tools/run_harness.sh && tests/lsp/run_harness.sh && tests/agent/run_harness.sh && tests/security/run_harness.sh && tests/perf/run_harness.sh && tests/pending/run_harness.sh`
    - pass (all snapshots written)
  - `nvim --headless -u NONE -l tests/check_quarantine.lua`
    - pass (3 timing-sensitive cases validated)
  - `nvim --headless -u NONE -l tests/check_pending.lua`
    - pass (2 pending cases validated)

## Falsifiers Checked
- [x] High-severity regression reaches release without gate failure
  - Guard: required CI jobs + suite failures hard-fail.
- [x] Tests rely on undeclared machine-local state
  - Guard: explicit skip/degradation paths in harnesses + deterministic fixture generation.

## Failure Modes and Residual Risk
1. Failure mode: timing-sensitive tests become flaky and silently ignored.
   - Discriminating check: `tests/check_quarantine.lua` + PR growth policy (`tests/check_quarantine_growth.sh`).
2. Failure mode: roadmap-dependent tests are silently deferred forever.
   - Discriminating check: `tests/check_pending.lua` with strict allowlist and stale-entry failure.
3. Failure mode: severe latency regression in diagnostics/completion/picker.
   - Discriminating check: `lua/jig/tests/perf/harness.lua` with budget gates.

Residual risk:
- Perf thresholds are conservative extreme-regression gates; tighter comparative baselines are deferred to WP-15.
- Pending tests for approval visibility and patch/diff pipeline remain until WP-17 implementation lands.

## Rollback Plan
- Revert command(s): `git revert 38506a2`
- Rollback notes: this commit is self-contained; reverting removes WP-12 harness additions and CI hooks without touching runtime core behavior.

## Docs and Security Impact
- Docs changed:
  - `docs/testing.jig.nvim.md`
  - `doc/jig-testing.txt`
  - `docs/roadmap/WP-12-DELTA.md`
  - `README.md`
  - `docs/architecture.jig.nvim.md`
- Network/exec/filesystem/policy impact:
  - Adds CI/test-only policy gates and fixture generation.
  - No startup auto-network behavior introduced.
  - No startup auto-install behavior introduced.

[quarantine-justification]
Added explicit allowlist entries for existing timing-sensitive tests (`ui:cmdline-open-close`, `tools:capture-concurrency-guard`, `agent:task-cancel-resume`) with deterministic retry metadata and CI enforcement.
