### PR TITLE
docs(roadmap): finalize WP-14 board state

### DIFF
--- a/docs/roadmap/EXECUTION_BOARD.md
+++ b/docs/roadmap/EXECUTION_BOARD.md
@@ -127,10 +127,10 @@ Updated at: `2026-02-21`
 - ADR(s): tbd
 
 ### WP-14: Release, Rollback, and Incident Operations
-- Status: `in-progress` (`current`)
+- Status: `done`
 - Depends on: `WP-13`
 - Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/18
-- PR(s): tbd
+- PR(s): https://github.com/Ismail-elkorchi/jig.nvim/pull/40
 - ADR(s): tbd
 - Deliverables (excerpt):
   - stable/edge release channel policy with persisted metadata


### PR DESCRIPTION
## Why
`WP-14` merged in PR #40, but `docs/roadmap/EXECUTION_BOARD.md` still showed `in-progress` and `PR(s): tbd`.

## What
- mark `WP-14` status as `done`
- set `WP-14` PR link to `https://github.com/Ismail-elkorchi/jig.nvim/pull/40`
- keep `WP-15` as `not-started` (`next`)

## Verification
- `rg -n "WP-14|WP-15|pull/40|Status: `done`" docs/roadmap/EXECUTION_BOARD.md`
