### PR TITLE
feat(tools): WP-16 toolchain lockfile and lifecycle commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,10 @@ jobs:
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigExec")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolHealth")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigTerm")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainInstall")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainUpdate")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRestore")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRollback")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpTrust")==0)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpList")==0)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigAgentContext")==0)' '+qa'
@@ -182,6 +186,10 @@ jobs:
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigExec")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolHealth")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigTerm")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainInstall")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainUpdate")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRestore")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRollback")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpTrust")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpList")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigAgentContext")==0)' '+qa'
@@ -272,6 +280,10 @@ jobs:
           rg -n '"command-execution-smoke"' tests/tools/snapshots/latest-headless.json
           rg -n '"capture-concurrency-guard"' tests/tools/snapshots/latest-headless.json
           rg -n '"timeout-or-nil-path"' tests/tools/snapshots/latest-headless.json
+          rg -n '"toolchain-install-restore-version-equality"' tests/tools/snapshots/latest-headless.json
+          rg -n '"toolchain-rollback-restores-previous-lock"' tests/tools/snapshots/latest-headless.json
+          rg -n '"toolchain-drift-visible-in-health"' tests/tools/snapshots/latest-headless.json
+          rg -n '"toolchain-drift-warning-via-jighealth"' tests/tools/snapshots/latest-headless.json
           rg -n '"safe-profile-isolation"' tests/tools/snapshots/latest-headless.json
 
       - name: Agent harness snapshot checks
@@ -361,11 +373,14 @@ jobs:
           set -euo pipefail
           tmp="$(mktemp -d)"
           XDG_DATA_HOME="$tmp/data" \
+          XDG_CONFIG_HOME="$tmp/config" \
           XDG_STATE_HOME="$tmp/state" \
           XDG_CACHE_HOME="$tmp/cache" \
           NVIM_APPNAME=jig-ci \
           nvim --headless -u ./init.lua '+qa'
           test ! -d "$tmp/data/jig-ci/lazy/lazy.nvim"
+          test ! -f "$tmp/config/jig-ci/jig-toolchain-manifest.json"
+          test ! -f "$tmp/config/jig-ci/jig-toolchain-lock.json"
 
       - name: Health check
         run: nvim --headless -u ./init.lua '+JigHealth' '+qa'

--- a/doc/jig-commands.txt
+++ b/doc/jig-commands.txt
@@ -33,6 +33,10 @@ COMMANDS
   :JigSymbols         optional-one Find symbols with fallback behavior
   :JigTerm            optional-one Open integrated terminal (default root or buffer directory)
   :JigToolHealth      none         Show shell, provider, and external tool integration summary
+  :JigToolchainInstall none         Install toolchain from manifest and write toolchain lockfile
+  :JigToolchainRestore none         Restore toolchain to versions pinned in toolchain lockfile
+  :JigToolchainRollback none         Restore previous toolchain lock backup and re-apply
+  :JigToolchainUpdate none         Update toolchain lock state from manifest with explicit command
   :JigUiProfile       optional-one Set accessibility profile (default|high-contrast|reduced-decoration|reduced-motion)
   :JigVerboseMap      one          Show keymap provenance via :verbose map <lhs>
   :JigVerboseSet      one          Show option provenance via :verbose set <option>?

--- a/doc/jig-tools.txt
+++ b/doc/jig-tools.txt
@@ -14,6 +14,18 @@ COMMANDS
   :JigTerm [root|buffer]
       Open interactive terminal in Jig root (default) or current buffer dir.
 
+  :JigToolchainInstall
+      Apply toolchain manifest and write toolchain lockfile.
+
+  :JigToolchainUpdate
+      Explicit toolchain update path; writes rollback backup before lock updates.
+
+  :JigToolchainRestore
+      Restore managed/system toolchain probes to lockfile-pinned versions.
+
+  :JigToolchainRollback
+      Restore previous toolchain lock backup and re-apply in one command.
+
 EXECUTION RULES
   - argv-first execution via vim.system()
   - no implicit shell=true
@@ -33,6 +45,7 @@ SAFE PROFILE
 POLICY
   Jig does not auto-install tools.
   Jig does not auto-run startup network actions.
+  Jig does not auto-update toolchains on startup.
 
 CHECKS
   :checkhealth jig

--- a/docs/architecture.jig.nvim.md
+++ b/docs/architecture.jig.nvim.md
@@ -40,8 +40,9 @@ Canonical help: `:help jig`
 - `tools/registry.lua`: required/recommended/optional external tool registry and install hints.
 - `tools/system.lua`: deterministic `vim.system` wrappers (timeouts, nil handling, capture queue).
 - `tools/terminal.lua`: terminal integration with mode visibility and command-state feedback.
+- `tools/toolchain.lua`: manifest+lockfile lifecycle for external toolchain install/update/restore/rollback and drift reporting.
 - `tools/health.lua`: shell/provider/tool health summaries and checkhealth integration.
-- `tools/init.lua`: command orchestration + `:JigExec`, `:JigToolHealth`, `:JigTerm`.
+- `tools/init.lua`: command orchestration + `:JigExec`, `:JigToolHealth`, `:JigTerm`, and `:JigToolchain*` lifecycle commands.
 - `security/config.lua`: runtime security policy defaults + override merge.
 - `security/startup_phase.lua`: startup phase boundary tracking (`startup` -> `done`).
 - `security/net_guard.lua`: startup network classification, deny-by-default, and trace hooks.

--- a/docs/commands.jig.nvim.md
+++ b/docs/commands.jig.nvim.md
@@ -34,6 +34,10 @@ Generated from the default runtime command surface. Do not edit manually.
 | `:JigSymbols` | `optional-one` | `no` | Find symbols with fallback behavior |
 | `:JigTerm` | `optional-one` | `no` | Open integrated terminal (default root or buffer directory) |
 | `:JigToolHealth` | `none` | `no` | Show shell, provider, and external tool integration summary |
+| `:JigToolchainInstall` | `none` | `no` | Install toolchain from manifest and write toolchain lockfile |
+| `:JigToolchainRestore` | `none` | `no` | Restore toolchain to versions pinned in toolchain lockfile |
+| `:JigToolchainRollback` | `none` | `no` | Restore previous toolchain lock backup and re-apply |
+| `:JigToolchainUpdate` | `none` | `no` | Update toolchain lock state from manifest with explicit command |
 | `:JigUiProfile` | `optional-one` | `no` | Set accessibility profile (default|high-contrast|reduced-decoration|reduced-motion) |
 | `:JigVerboseMap` | `one` | `no` | Show keymap provenance via :verbose map <lhs> |
 | `:JigVerboseSet` | `one` | `no` | Show option provenance via :verbose set <option>? |

--- a/docs/tools.jig.nvim.md
+++ b/docs/tools.jig.nvim.md
@@ -69,6 +69,30 @@ Health output provides:
 - `:JigExec {cmd...}`
 - `:JigToolHealth`
 - `:JigTerm [root|buffer]`
+- `:JigToolchainInstall`
+- `:JigToolchainUpdate`
+- `:JigToolchainRestore`
+- `:JigToolchainRollback`
+
+## Toolchain Lockfile Lifecycle (WP-16)
+Toolchain lifecycle state is independent from plugin lockfiles.
+
+Default paths:
+- manifest: `stdpath("config")/jig-toolchain-manifest.json`
+- lockfile: `stdpath("config")/jig-toolchain-lock.json`
+- rollback backup: `stdpath("state")/jig/toolchain-lock.previous.json`
+- managed install root: `stdpath("data")/jig/toolchain/bin`
+
+Lifecycle behavior:
+- `:JigToolchainInstall`: initialize/apply manifest and write lockfile.
+- `:JigToolchainUpdate`: explicit update path; writes backup before lock changes.
+- `:JigToolchainRestore`: reconcile current tool versions to lockfile versions.
+- `:JigToolchainRollback`: restore previous lock backup and re-apply.
+
+Operational policy:
+- no startup auto-install/update
+- no startup network actions
+- drift is reported by `:JigHealth` / `:JigToolHealth` when lockfile and probed versions diverge.
 
 All commands are disabled in `NVIM_APPNAME=jig-safe`.
 

--- a/lua/jig/tests/tools/harness.lua
+++ b/lua/jig/tests/tools/harness.lua
@@ -2,6 +2,7 @@ local health = require("jig.tools.health")
 local platform = require("jig.platform")
 local registry = require("jig.tools.registry")
 local system = require("jig.tools.system")
+local toolchain = require("jig.tools.toolchain")
 
 local M = {}
 
@@ -46,6 +47,10 @@ local function run_safe_assertions()
       "+lua assert(vim.fn.exists(':JigExec')==0)",
       "+lua assert(vim.fn.exists(':JigToolHealth')==0)",
       "+lua assert(vim.fn.exists(':JigTerm')==0)",
+      "+lua assert(vim.fn.exists(':JigToolchainInstall')==0)",
+      "+lua assert(vim.fn.exists(':JigToolchainUpdate')==0)",
+      "+lua assert(vim.fn.exists(':JigToolchainRestore')==0)",
+      "+lua assert(vim.fn.exists(':JigToolchainRollback')==0)",
       "+lua assert(package.loaded['jig.tools']==nil)",
       "+qa",
     }, {
@@ -238,6 +243,102 @@ local function capture_guard_argv()
   return nil, nil, "none"
 end
 
+local function read_json(path)
+  local lines = vim.fn.readfile(path)
+  return vim.json.decode(table.concat(lines, "\n"))
+end
+
+local function write_json(path, payload)
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  vim.fn.writefile({ vim.json.encode(payload) }, path)
+end
+
+local function fake_tool_name(base)
+  if platform.os.is_windows() then
+    return base .. ".cmd"
+  end
+  return base
+end
+
+local function write_fake_tool(path, version)
+  local lines
+  if platform.os.is_windows() then
+    lines = {
+      "@echo off",
+      "echo fakefmt " .. tostring(version),
+    }
+  else
+    lines = {
+      "#!/usr/bin/env sh",
+      "echo fakefmt " .. tostring(version),
+    }
+  end
+
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  vim.fn.writefile(lines, path)
+  if not platform.os.is_windows() then
+    vim.uv.fs_chmod(path, 493) -- 0755
+  end
+end
+
+local function make_toolchain_fixture()
+  local root = vim.fn.tempname()
+  vim.fn.mkdir(root, "p")
+
+  local source = root .. "/source/" .. fake_tool_name("fakefmt")
+  local manifest = root .. "/manifest.json"
+  local lockfile = root .. "/lock.json"
+  local rollback = root .. "/rollback.json"
+  local install_root = root .. "/install/bin"
+
+  write_fake_tool(source, "1.0.0")
+
+  local manifest_doc = {
+    schema = "jig-toolchain-manifest-v1",
+    install_root = install_root,
+    tools = {
+      {
+        name = "fakefmt",
+        mode = "managed",
+        executable = fake_tool_name("fakefmt"),
+        source = "fixture-local",
+        source_path = source,
+        version = "1.0.0",
+        platform = "any",
+        probe_args = { "--version" },
+      },
+    },
+  }
+  write_json(manifest, manifest_doc)
+
+  local function cleanup()
+    vim.fn.delete(root, "rf")
+  end
+
+  return {
+    root = root,
+    source = source,
+    manifest = manifest,
+    lockfile = lockfile,
+    rollback = rollback,
+    install_root = install_root,
+    executable = install_root .. "/" .. fake_tool_name("fakefmt"),
+    cleanup = cleanup,
+  }
+end
+
+local function toolchain_opts(paths)
+  return {
+    manifest_path = paths.manifest,
+    lockfile_path = paths.lockfile,
+    rollback_path = paths.rollback,
+    install_root = paths.install_root,
+    timeout_ms = 2000,
+    actor = "user",
+    origin = "tests.toolchain",
+  }
+end
+
 local cases = {
   {
     id = "default-command-surface",
@@ -245,10 +346,18 @@ local cases = {
       assert(command_exists("JigExec"), "JigExec missing")
       assert(command_exists("JigToolHealth"), "JigToolHealth missing")
       assert(command_exists("JigTerm"), "JigTerm missing")
+      assert(command_exists("JigToolchainInstall"), "JigToolchainInstall missing")
+      assert(command_exists("JigToolchainUpdate"), "JigToolchainUpdate missing")
+      assert(command_exists("JigToolchainRestore"), "JigToolchainRestore missing")
+      assert(command_exists("JigToolchainRollback"), "JigToolchainRollback missing")
       return {
         JigExec = true,
         JigToolHealth = true,
         JigTerm = true,
+        JigToolchainInstall = true,
+        JigToolchainUpdate = true,
+        JigToolchainRestore = true,
+        JigToolchainRollback = true,
       }
     end,
   },
@@ -387,6 +496,196 @@ local cases = {
         shell = shell,
         reason = result.reason,
         stderr = result.stderr,
+      }
+    end,
+  },
+  {
+    id = "toolchain-install-restore-version-equality",
+    run = function()
+      local fixture = make_toolchain_fixture()
+      local opts = toolchain_opts(fixture)
+
+      local installed = toolchain.install(opts)
+      assert(
+        installed.ok == true,
+        "toolchain install failed: " .. table.concat(installed.errors or {}, "; ")
+      )
+
+      local lock1 = read_json(fixture.lockfile)
+      local before = lock1.tools[1]
+      assert(before.version == "1.0.0", "unexpected initial locked version")
+
+      write_fake_tool(fixture.executable, "9.9.9")
+      local drift = toolchain.health_report(opts)
+      assert(drift.lockfile_present == true, "toolchain lockfile should be present")
+      assert(tonumber(drift.drift_count) == 1, "drift_count should be 1 after mutation")
+
+      local restored = toolchain.restore(opts)
+      assert(
+        restored.ok == true,
+        "toolchain restore failed: " .. table.concat(restored.errors or {}, "; ")
+      )
+
+      local probe = system.run_sync({ fixture.executable, "--version" }, { timeout_ms = 2000 })
+      assert(probe.ok == true, "probe after restore failed")
+      assert(probe.stdout:find("1.0.0", 1, true) ~= nil, "restore did not recover expected version")
+
+      fixture.cleanup()
+      return {
+        locked_version = before.version,
+        drift_count = drift.drift_count,
+        restored_version = "1.0.0",
+      }
+    end,
+  },
+  {
+    id = "toolchain-rollback-restores-previous-lock",
+    run = function()
+      local fixture = make_toolchain_fixture()
+      local opts = toolchain_opts(fixture)
+
+      local first = toolchain.install(opts)
+      assert(first.ok == true, "initial install failed")
+
+      local manifest = read_json(fixture.manifest)
+      manifest.tools[1].version = "2.0.0"
+      write_json(fixture.manifest, manifest)
+      write_fake_tool(fixture.source, "2.0.0")
+
+      local updated = toolchain.update(opts)
+      assert(updated.ok == true, "update failed: " .. table.concat(updated.errors or {}, "; "))
+
+      local lock_updated = read_json(fixture.lockfile)
+      assert(lock_updated.tools[1].version == "2.0.0", "update lock version mismatch")
+
+      local rolled = toolchain.rollback(opts)
+      assert(rolled.ok == true, "rollback failed: " .. table.concat(rolled.errors or {}, "; "))
+
+      local lock_rolled = read_json(fixture.lockfile)
+      assert(
+        lock_rolled.tools[1].version == "1.0.0",
+        "rollback lockfile did not restore previous version"
+      )
+
+      local probe = system.run_sync({ fixture.executable, "--version" }, { timeout_ms = 2000 })
+      assert(probe.ok == true, "probe after rollback failed")
+      assert(
+        probe.stdout:find("1.0.0", 1, true) ~= nil,
+        "rollback did not restore tool binary version"
+      )
+
+      fixture.cleanup()
+      return {
+        before = "1.0.0",
+        updated = "2.0.0",
+        rolled_back = "1.0.0",
+      }
+    end,
+  },
+  {
+    id = "toolchain-drift-visible-in-health",
+    run = function()
+      local fixture = make_toolchain_fixture()
+      local opts = toolchain_opts(fixture)
+
+      local installed = toolchain.install(opts)
+      assert(installed.ok == true, "toolchain install failed")
+
+      write_fake_tool(fixture.executable, "7.7.7")
+      local previous = vim.g.jig_toolchain
+      vim.g.jig_toolchain = {
+        manifest_path = fixture.manifest,
+        lockfile_path = fixture.lockfile,
+        rollback_path = fixture.rollback,
+        install_root = fixture.install_root,
+        timeout_ms = 2000,
+      }
+
+      vim.cmd("JigToolHealth")
+      local state = vim.g.jig_tool_health_last
+      assert(type(state) == "table" and type(state.lines) == "table", "JigToolHealth state missing")
+      local joined = table.concat(state.lines, "\n")
+      local report = state.report
+      assert(
+        report.toolchain and report.toolchain.drift_count == 1,
+        "JigToolHealth drift_count mismatch"
+      )
+      assert(
+        joined:lower():find("drift", 1, true) ~= nil,
+        "health output should include drift wording"
+      )
+      vim.g.jig_toolchain = previous
+
+      fixture.cleanup()
+      return {
+        drift_count = report.toolchain.drift_count,
+      }
+    end,
+  },
+  {
+    id = "toolchain-drift-warning-via-jighealth",
+    run = function()
+      local fixture = make_toolchain_fixture()
+      local opts = toolchain_opts(fixture)
+
+      local installed = toolchain.install(opts)
+      assert(installed.ok == true, "toolchain install failed")
+      write_fake_tool(fixture.executable, "5.5.5")
+
+      local previous_toolchain = vim.g.jig_toolchain
+      vim.g.jig_toolchain = {
+        manifest_path = fixture.manifest,
+        lockfile_path = fixture.lockfile,
+        rollback_path = fixture.rollback,
+        install_root = fixture.install_root,
+        timeout_ms = 2000,
+      }
+
+      local captured = {}
+      local original_health = {
+        start = vim.health.start,
+        ok = vim.health.ok,
+        warn = vim.health.warn,
+        info = vim.health.info,
+        error = vim.health.error,
+      }
+
+      vim.health.start = function(msg)
+        captured[#captured + 1] = "start:" .. tostring(msg)
+      end
+      vim.health.ok = function(msg)
+        captured[#captured + 1] = "ok:" .. tostring(msg)
+      end
+      vim.health.warn = function(msg)
+        captured[#captured + 1] = "warn:" .. tostring(msg)
+      end
+      vim.health.info = function(msg)
+        captured[#captured + 1] = "info:" .. tostring(msg)
+      end
+      vim.health.error = function(msg)
+        captured[#captured + 1] = "error:" .. tostring(msg)
+      end
+
+      local core_health = require("jig.core.health")
+      core_health.check()
+
+      vim.health.start = original_health.start
+      vim.health.ok = original_health.ok
+      vim.health.warn = original_health.warn
+      vim.health.info = original_health.info
+      vim.health.error = original_health.error
+      vim.g.jig_toolchain = previous_toolchain
+
+      fixture.cleanup()
+
+      local joined = table.concat(captured, "\n"):lower()
+      assert(
+        joined:find("toolchain drift detected", 1, true) ~= nil,
+        "JigHealth check did not surface toolchain drift warning"
+      )
+
+      return {
+        warning = "toolchain drift detected",
       }
     end,
   },

--- a/lua/jig/tools/toolchain.lua
+++ b/lua/jig/tools/toolchain.lua
@@ -1,0 +1,768 @@
+local platform = require("jig.platform")
+local registry = require("jig.tools.registry")
+local system = require("jig.tools.system")
+
+local M = {}
+
+local MANIFEST_SCHEMA = "jig-toolchain-manifest-v1"
+local LOCK_SCHEMA = "jig-toolchain-lock-v1"
+
+local function now_iso()
+  return os.date("!%Y-%m-%dT%H:%M:%SZ")
+end
+
+local function stdpaths()
+  return {
+    config = vim.fn.stdpath("config"),
+    data = vim.fn.stdpath("data"),
+    state = vim.fn.stdpath("state"),
+  }
+end
+
+local function defaults(opts)
+  local user = vim.g.jig_toolchain
+  if type(user) ~= "table" then
+    user = {}
+  end
+
+  local paths = stdpaths()
+  opts = opts or {}
+
+  local install_root = opts.install_root
+    or user.install_root
+    or (paths.data .. "/jig/toolchain/bin")
+  local artifact_root = opts.artifact_root
+    or user.artifact_root
+    or (paths.state .. "/jig/toolchain/artifacts")
+
+  return {
+    timeout_ms = tonumber(opts.timeout_ms or user.timeout_ms) or 4000,
+    install_root = install_root,
+    artifact_root = artifact_root,
+    manifest_path = opts.manifest_path
+      or user.manifest_path
+      or (paths.config .. "/jig-toolchain-manifest.json"),
+    lockfile_path = opts.lockfile_path
+      or user.lockfile_path
+      or (paths.config .. "/jig-toolchain-lock.json"),
+    rollback_path = opts.rollback_path
+      or user.rollback_path
+      or (paths.state .. "/jig/toolchain-lock.previous.json"),
+    actor = opts.actor or "user",
+    origin = opts.origin or "jig.toolchain",
+  }
+end
+
+local function file_exists(path)
+  return type(path) == "string" and path ~= "" and vim.uv.fs_stat(path) ~= nil
+end
+
+local function mkdir_parent(path)
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+end
+
+local function read_json(path)
+  if not file_exists(path) then
+    return nil, "missing_file"
+  end
+  local lines = vim.fn.readfile(path)
+  local raw = table.concat(lines, "\n")
+  local ok, decoded = pcall(vim.json.decode, raw)
+  if not ok or type(decoded) ~= "table" then
+    return nil, "invalid_json"
+  end
+  return decoded, nil
+end
+
+local function write_json(path, payload)
+  mkdir_parent(path)
+  vim.fn.writefile({ vim.json.encode(payload) }, path)
+end
+
+local function copy_file(src, dst)
+  local content = vim.fn.readfile(src, "b")
+  mkdir_parent(dst)
+  vim.fn.writefile(content, dst, "b")
+end
+
+local function is_windows()
+  return platform.os.is_windows()
+end
+
+local function normalize_path(path)
+  if type(path) ~= "string" then
+    return ""
+  end
+  return platform.path.normalize(path, { slash = false })
+end
+
+local function ensure_executable(path)
+  if is_windows() then
+    return
+  end
+  pcall(vim.uv.fs_chmod, path, 493) -- 0755
+end
+
+local function parse_version(value)
+  local raw = tostring(value or "")
+  local first = raw:match("(%d+%.%d+[%w%._%-+]*)")
+  if first ~= nil then
+    return first
+  end
+  return ""
+end
+
+local function detect_platform_label()
+  local os_info = platform.os.detect()
+  return string.format("%s-%s", tostring(os_info.class), tostring(os_info.arch))
+end
+
+local function default_probe_args(entry)
+  if type(entry.probe_args) == "table" and #entry.probe_args > 0 then
+    return vim.deepcopy(entry.probe_args)
+  end
+  return { "--version" }
+end
+
+local function probe_tool(executable, entry, cfg)
+  local argv = { executable }
+  for _, token in ipairs(default_probe_args(entry)) do
+    table.insert(argv, tostring(token))
+  end
+
+  local result = system.run_sync(argv, {
+    timeout_ms = cfg.timeout_ms,
+    actor = cfg.actor,
+    origin = cfg.origin .. ".probe",
+    allow_network = false,
+    cwd = vim.uv.cwd(),
+  })
+
+  local probe_output = table.concat({ result.stdout or "", result.stderr or "" }, "\n")
+  local detected = parse_version(probe_output)
+
+  return {
+    ok = result.ok == true,
+    argv = argv,
+    result = result,
+    output = probe_output,
+    version = detected,
+  }
+end
+
+local function expected_version(entry, probe)
+  local pinned = tostring(entry.version or "")
+  if pinned ~= "" then
+    return pinned
+  end
+  return tostring(probe.version or "")
+end
+
+local function sha256_file(path)
+  if not file_exists(path) then
+    return ""
+  end
+  local lines = vim.fn.readfile(path, "b")
+  local payload = table.concat(lines, "\n")
+  local digest = vim.fn.sha256(payload)
+  if type(digest) ~= "string" or digest == "" then
+    return ""
+  end
+  return "sha256:" .. digest
+end
+
+local function sanitize_filename_token(value)
+  return tostring(value or ""):gsub("[^%w%._%-]", "_")
+end
+
+local function artifact_extension(entry)
+  local executable = tostring(entry.executable or "")
+  local suffix = executable:match("(%.[%w]+)$")
+  if suffix ~= nil then
+    return suffix
+  end
+  return ""
+end
+
+local function artifact_path(cfg, entry, version)
+  local filename = string.format(
+    "%s-%s%s",
+    sanitize_filename_token(entry.name),
+    sanitize_filename_token(version),
+    artifact_extension(entry)
+  )
+  return normalize_path(cfg.artifact_root .. "/" .. filename)
+end
+
+local function normalize_manifest_tool(entry)
+  if type(entry) ~= "table" then
+    return nil
+  end
+
+  local name = tostring(entry.name or "")
+  if name == "" then
+    return nil
+  end
+
+  local mode = tostring(entry.mode or "system")
+  if mode ~= "system" and mode ~= "managed" then
+    mode = "system"
+  end
+
+  local executable = tostring(entry.executable or name)
+  local source = tostring(entry.source or (mode == "managed" and "local-artifact" or "system-path"))
+
+  local normalized = {
+    name = name,
+    mode = mode,
+    executable = executable,
+    source = source,
+    version = tostring(entry.version or ""),
+    source_path = tostring(entry.source_path or ""),
+    platform = tostring(entry.platform or "any"),
+    checksum = tostring(entry.checksum or ""),
+    probe_args = default_probe_args(entry),
+  }
+
+  return normalized
+end
+
+local function sorted_registry_tools()
+  local names = {}
+  for name in pairs(registry.tools) do
+    names[#names + 1] = name
+  end
+  table.sort(names)
+  return names
+end
+
+function M.default_manifest(opts)
+  local cfg = defaults(opts)
+  local tools = {}
+
+  for _, name in ipairs(sorted_registry_tools()) do
+    local spec = registry.get(name)
+    local executable = spec and spec.executables and spec.executables[1] or name
+    tools[#tools + 1] = {
+      name = name,
+      mode = "system",
+      executable = executable,
+      source = "system-path",
+      version = "",
+      platform = "any",
+      checksum = "",
+      probe_args = { "--version" },
+    }
+  end
+
+  return {
+    schema = MANIFEST_SCHEMA,
+    generated_at = now_iso(),
+    install_root = cfg.install_root,
+    tools = tools,
+  }
+end
+
+local function normalize_manifest(doc, cfg)
+  if type(doc) ~= "table" then
+    return nil, "manifest must be a JSON object"
+  end
+
+  local schema = tostring(doc.schema or "")
+  if schema ~= "" and schema ~= MANIFEST_SCHEMA then
+    return nil, "unsupported manifest schema: " .. schema
+  end
+
+  local tools = {}
+  for _, raw in ipairs(doc.tools or {}) do
+    local normalized = normalize_manifest_tool(raw)
+    if normalized == nil then
+      return nil, "manifest tools include invalid entry"
+    end
+    tools[#tools + 1] = normalized
+  end
+
+  if #tools == 0 then
+    return nil, "manifest tools list cannot be empty"
+  end
+
+  return {
+    schema = MANIFEST_SCHEMA,
+    install_root = tostring(doc.install_root or cfg.install_root),
+    tools = tools,
+  },
+    nil
+end
+
+local function load_manifest(cfg, opts)
+  opts = opts or {}
+  local existing, reason = read_json(cfg.manifest_path)
+  if existing == nil then
+    if opts.create_if_missing ~= true then
+      return nil, "manifest_missing"
+    end
+    local manifest = M.default_manifest(cfg)
+    write_json(cfg.manifest_path, manifest)
+    return normalize_manifest(manifest, cfg)
+  end
+  if reason ~= nil then
+    return nil, reason
+  end
+  return normalize_manifest(existing, cfg)
+end
+
+local function backup_lockfile(cfg)
+  if not file_exists(cfg.lockfile_path) then
+    return false
+  end
+  copy_file(cfg.lockfile_path, cfg.rollback_path)
+  return true
+end
+
+local function managed_destination(cfg, entry)
+  local filename = entry.executable
+  if is_windows() and filename:sub(-4):lower() ~= ".cmd" and filename:sub(-4):lower() ~= ".exe" then
+    filename = filename .. ".cmd"
+  end
+  return normalize_path(cfg.install_root .. "/" .. filename)
+end
+
+local function resolve_system_executable(entry)
+  local executable = platform.executable_path(entry.executable)
+  if executable ~= "" then
+    return executable
+  end
+  return ""
+end
+
+local function install_tool(entry, manifest, cfg)
+  local tool = {
+    name = entry.name,
+    mode = entry.mode,
+    source = entry.source,
+    platform = detect_platform_label(),
+    checksum = "",
+    install_root = manifest.install_root,
+    probe_args = vim.deepcopy(entry.probe_args),
+    executable = "",
+    provenance = {
+      source_path = "",
+      command = cfg.origin,
+    },
+  }
+
+  if entry.mode == "managed" then
+    if entry.source_path == "" or not file_exists(entry.source_path) then
+      return nil,
+        string.format(
+          "tool %s managed source_path missing: %s",
+          entry.name,
+          entry.source_path ~= "" and entry.source_path or "<empty>"
+        )
+    end
+    local destination = managed_destination(cfg, entry)
+    copy_file(entry.source_path, destination)
+    ensure_executable(destination)
+    tool.executable = destination
+    tool.provenance.source_path = normalize_path(entry.source_path)
+    tool.checksum = entry.checksum ~= "" and entry.checksum or sha256_file(destination)
+  else
+    local executable = resolve_system_executable(entry)
+    if executable == "" then
+      return nil,
+        string.format("tool %s executable not found in PATH: %s", entry.name, entry.executable)
+    end
+    tool.executable = normalize_path(executable)
+    if entry.checksum ~= "" then
+      tool.checksum = entry.checksum
+    end
+  end
+
+  local probe = probe_tool(tool.executable, entry, cfg)
+  if probe.ok ~= true then
+    return nil, string.format("tool %s probe failed: %s", entry.name, tostring(probe.result.reason))
+  end
+
+  local expected = expected_version(entry, probe)
+  if expected == "" then
+    return nil, string.format("tool %s version probe returned empty output", entry.name)
+  end
+
+  if entry.version ~= "" and expected ~= probe.version then
+    return nil,
+      string.format(
+        "tool %s version mismatch (expected %s, probed %s)",
+        entry.name,
+        entry.version,
+        probe.version
+      )
+  end
+
+  tool.version = expected
+  tool.detected_version = probe.version
+  tool.probe_output = vim.trim(probe.output)
+  if entry.mode == "managed" then
+    local archived = artifact_path(cfg, entry, expected)
+    copy_file(tool.executable, archived)
+    ensure_executable(archived)
+    tool.provenance.archive_path = archived
+  end
+
+  return tool, nil
+end
+
+local function write_lockfile(cfg, manifest, tools, action)
+  local os_info = platform.os.detect()
+  local lock = {
+    schema = LOCK_SCHEMA,
+    generated_at = now_iso(),
+    install_root = manifest.install_root,
+    provenance = {
+      action = action,
+      manifest_path = cfg.manifest_path,
+      lockfile_path = cfg.lockfile_path,
+      actor = cfg.actor,
+      origin = cfg.origin,
+      host = {
+        os_class = os_info.class,
+        arch = os_info.arch,
+      },
+    },
+    tools = tools,
+  }
+
+  write_json(cfg.lockfile_path, lock)
+  return lock
+end
+
+local function run_manifest_apply(action, opts)
+  local cfg = defaults(opts)
+  local manifest, manifest_err = load_manifest(cfg, { create_if_missing = action ~= "restore" })
+  if manifest == nil then
+    return {
+      ok = false,
+      action = action,
+      reason = manifest_err,
+      errors = { "manifest load failed: " .. tostring(manifest_err) },
+      manifest_path = cfg.manifest_path,
+      lockfile_path = cfg.lockfile_path,
+      rollback_path = cfg.rollback_path,
+      install_root = cfg.install_root,
+      tools = {},
+    }
+  end
+
+  cfg.install_root = manifest.install_root
+  vim.fn.mkdir(cfg.install_root, "p")
+  vim.fn.mkdir(cfg.artifact_root, "p")
+
+  local backed_up = backup_lockfile(cfg)
+  local tools = {}
+  local errors = {}
+
+  for _, entry in ipairs(manifest.tools) do
+    local installed, install_err = install_tool(entry, manifest, cfg)
+    if installed then
+      tools[#tools + 1] = installed
+    else
+      errors[#errors + 1] = install_err
+    end
+  end
+
+  local lock = nil
+  if #errors == 0 then
+    lock = write_lockfile(cfg, manifest, tools, action)
+  end
+
+  return {
+    ok = #errors == 0,
+    action = action,
+    reason = #errors == 0 and nil or "apply_failed",
+    manifest_path = cfg.manifest_path,
+    lockfile_path = cfg.lockfile_path,
+    rollback_path = cfg.rollback_path,
+    install_root = cfg.install_root,
+    backed_up = backed_up,
+    errors = errors,
+    tools = tools,
+    lock = lock,
+  }
+end
+
+local function load_lockfile(cfg)
+  local lock, reason = read_json(cfg.lockfile_path)
+  if lock == nil then
+    return nil, reason
+  end
+  if type(lock.tools) ~= "table" then
+    return nil, "lockfile tools missing"
+  end
+  return lock, nil
+end
+
+local function restore_tool(tool, cfg)
+  local entry = vim.deepcopy(tool)
+  local errors = {}
+
+  if entry.mode == "managed" then
+    local archive_path = type(entry.provenance) == "table"
+        and tostring(entry.provenance.archive_path or "")
+      or ""
+    local source_path = type(entry.provenance) == "table"
+        and tostring(entry.provenance.source_path or "")
+      or ""
+    local restore_source = archive_path
+    if restore_source == "" or not file_exists(restore_source) then
+      restore_source = source_path
+    end
+
+    if restore_source == "" or not file_exists(restore_source) then
+      errors[#errors + 1] = string.format(
+        "tool %s restore source missing: archive=%s source=%s",
+        tostring(entry.name),
+        archive_path,
+        source_path
+      )
+    else
+      copy_file(restore_source, entry.executable)
+      ensure_executable(entry.executable)
+    end
+  end
+
+  local probe = probe_tool(entry.executable, entry, cfg)
+  entry.probe_ok = probe.ok
+  entry.probe_version = probe.version
+  entry.probe_output = vim.trim(probe.output)
+
+  if probe.ok ~= true then
+    errors[#errors + 1] = string.format("tool %s probe failed during restore", tostring(entry.name))
+  elseif tostring(entry.version or "") ~= tostring(probe.version or "") then
+    errors[#errors + 1] = string.format(
+      "tool %s version drift: expected %s got %s",
+      tostring(entry.name),
+      tostring(entry.version),
+      tostring(probe.version)
+    )
+  end
+
+  return entry, errors
+end
+
+function M.install(opts)
+  return run_manifest_apply("install", opts)
+end
+
+function M.update(opts)
+  return run_manifest_apply("update", opts)
+end
+
+function M.restore(opts)
+  local cfg = defaults(opts)
+  local lock, lock_err = load_lockfile(cfg)
+  if lock == nil then
+    return {
+      ok = false,
+      action = "restore",
+      reason = lock_err,
+      errors = { "lockfile load failed: " .. tostring(lock_err) },
+      manifest_path = cfg.manifest_path,
+      lockfile_path = cfg.lockfile_path,
+      rollback_path = cfg.rollback_path,
+      install_root = cfg.install_root,
+      tools = {},
+    }
+  end
+
+  local checked = {}
+  local errors = {}
+  for _, tool in ipairs(lock.tools or {}) do
+    local restored, tool_errors = restore_tool(tool, cfg)
+    checked[#checked + 1] = restored
+    for _, item in ipairs(tool_errors) do
+      errors[#errors + 1] = item
+    end
+  end
+
+  return {
+    ok = #errors == 0,
+    action = "restore",
+    reason = #errors == 0 and nil or "restore_failed",
+    manifest_path = cfg.manifest_path,
+    lockfile_path = cfg.lockfile_path,
+    rollback_path = cfg.rollback_path,
+    install_root = tostring(lock.install_root or cfg.install_root),
+    tools = checked,
+    errors = errors,
+    lock = lock,
+  }
+end
+
+function M.rollback(opts)
+  local cfg = defaults(opts)
+  if not file_exists(cfg.rollback_path) then
+    return {
+      ok = false,
+      action = "rollback",
+      reason = "rollback_missing",
+      errors = { "rollback lockfile missing: " .. cfg.rollback_path },
+      manifest_path = cfg.manifest_path,
+      lockfile_path = cfg.lockfile_path,
+      rollback_path = cfg.rollback_path,
+      install_root = cfg.install_root,
+      tools = {},
+    }
+  end
+
+  copy_file(cfg.rollback_path, cfg.lockfile_path)
+  local restored = M.restore(vim.tbl_extend("force", opts or {}, cfg))
+  restored.action = "rollback"
+  return restored
+end
+
+function M.health_report(opts)
+  local cfg = defaults(opts)
+  local lock, lock_err = load_lockfile(cfg)
+
+  if lock == nil then
+    return {
+      ok = false,
+      lockfile_present = false,
+      reason = lock_err,
+      drift_count = 0,
+      tools = {},
+      lockfile_path = cfg.lockfile_path,
+      manifest_path = cfg.manifest_path,
+      install_root = cfg.install_root,
+    }
+  end
+
+  local tools = {}
+  local drift_count = 0
+  for _, tool in ipairs(lock.tools or {}) do
+    local probe = probe_tool(tool.executable, tool, cfg)
+    local drift = probe.ok ~= true or tostring(probe.version or "") ~= tostring(tool.version or "")
+    if drift then
+      drift_count = drift_count + 1
+    end
+    tools[#tools + 1] = {
+      name = tool.name,
+      expected_version = tool.version,
+      detected_version = probe.version,
+      executable = tool.executable,
+      source = tool.source,
+      mode = tool.mode,
+      checksum = tool.checksum,
+      drift = drift,
+      probe_ok = probe.ok,
+      reason = probe.ok and nil or (probe.result and probe.result.reason or "probe_failed"),
+    }
+  end
+
+  return {
+    ok = true,
+    lockfile_present = true,
+    schema = lock.schema,
+    lockfile_generated_at = lock.generated_at,
+    lockfile_path = cfg.lockfile_path,
+    manifest_path = cfg.manifest_path,
+    install_root = tostring(lock.install_root or cfg.install_root),
+    drift_count = drift_count,
+    tools = tools,
+  }
+end
+
+local function fmt_errors(errors)
+  if type(errors) ~= "table" then
+    return {}
+  end
+  local lines = {}
+  for _, item in ipairs(errors) do
+    lines[#lines + 1] = "- " .. tostring(item)
+  end
+  return lines
+end
+
+function M.render_action_lines(report)
+  local lines = {
+    string.format("Jig toolchain action: %s", tostring(report.action or "unknown")),
+    string.rep("=", 64),
+    string.format("ok: %s", tostring(report.ok == true)),
+    string.format("manifest_path: %s", tostring(report.manifest_path or "")),
+    string.format("lockfile_path: %s", tostring(report.lockfile_path or "")),
+    string.format("rollback_path: %s", tostring(report.rollback_path or "")),
+    string.format("install_root: %s", tostring(report.install_root or "")),
+    string.format("backup_created: %s", tostring(report.backed_up == true)),
+  }
+
+  if report.reason then
+    lines[#lines + 1] = string.format("reason: %s", tostring(report.reason))
+  end
+
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "tools:"
+  for _, tool in ipairs(report.tools or {}) do
+    lines[#lines + 1] = string.format(
+      "- %s mode=%s version=%s executable=%s",
+      tostring(tool.name),
+      tostring(tool.mode or ""),
+      tostring(tool.version or tool.probe_version or ""),
+      tostring(tool.executable or "")
+    )
+  end
+
+  if #(report.errors or {}) > 0 then
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = "errors:"
+    vim.list_extend(lines, fmt_errors(report.errors))
+  end
+
+  return lines
+end
+
+function M.render_health_lines(report)
+  local lines = {
+    "Jig toolchain drift report",
+    string.rep("=", 64),
+    string.format("lockfile_present: %s", tostring(report.lockfile_present == true)),
+    string.format("lockfile_path: %s", tostring(report.lockfile_path or "")),
+    string.format("manifest_path: %s", tostring(report.manifest_path or "")),
+    string.format("install_root: %s", tostring(report.install_root or "")),
+    string.format("drift_count: %d", tonumber(report.drift_count) or 0),
+  }
+
+  if report.lockfile_generated_at then
+    lines[#lines + 1] =
+      string.format("lockfile_generated_at: %s", tostring(report.lockfile_generated_at))
+  end
+
+  if report.lockfile_present ~= true then
+    lines[#lines + 1] =
+      "lockfile missing. Run :JigToolchainInstall to create or refresh lock state explicitly."
+    return lines
+  end
+
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "tools:"
+  for _, tool in ipairs(report.tools or {}) do
+    if tool.drift then
+      lines[#lines + 1] = string.format(
+        "- %s drift expected=%s detected=%s executable=%s",
+        tostring(tool.name),
+        tostring(tool.expected_version or ""),
+        tostring(tool.detected_version or "<probe-failed>"),
+        tostring(tool.executable or "")
+      )
+    else
+      lines[#lines + 1] = string.format(
+        "- %s ok version=%s executable=%s",
+        tostring(tool.name),
+        tostring(tool.expected_version or ""),
+        tostring(tool.executable or "")
+      )
+    end
+  end
+
+  return lines
+end
+
+return M

--- a/tests/run_harness.lua
+++ b/tests/run_harness.lua
@@ -61,10 +61,15 @@ local function run_startup_smoke()
   assert(vim.fn.exists(":JigKeys") == 2, "JigKeys missing")
   assert(vim.fn.exists(":JigFiles") == 2, "JigFiles missing")
   assert(vim.fn.exists(":JigExec") == 2, "JigExec missing")
+  assert(vim.fn.exists(":JigToolchainInstall") == 2, "JigToolchainInstall missing")
+  assert(vim.fn.exists(":JigToolchainUpdate") == 2, "JigToolchainUpdate missing")
+  assert(vim.fn.exists(":JigToolchainRestore") == 2, "JigToolchainRestore missing")
+  assert(vim.fn.exists(":JigToolchainRollback") == 2, "JigToolchainRollback missing")
 
   local tmp = vim.fn.tempname()
   vim.fn.mkdir(tmp, "p")
   local env = vim.fn.environ()
+  env.XDG_CONFIG_HOME = join(tmp, "config")
   env.XDG_DATA_HOME = join(tmp, "data")
   env.XDG_STATE_HOME = join(tmp, "state")
   env.XDG_CACHE_HOME = join(tmp, "cache")
@@ -79,6 +84,14 @@ local function run_startup_smoke()
   assert(
     vim.fn.isdirectory(tmp .. "/data/jig-ci/lazy/lazy.nvim") == 0,
     "startup auto-install side effect"
+  )
+  assert(
+    vim.fn.filereadable(tmp .. "/config/jig-ci/jig-toolchain-manifest.json") == 0,
+    "startup auto-created toolchain manifest"
+  )
+  assert(
+    vim.fn.filereadable(tmp .. "/config/jig-ci/jig-toolchain-lock.json") == 0,
+    "startup auto-created toolchain lockfile"
   )
   vim.fn.delete(tmp, "rf")
 


### PR DESCRIPTION
Closes #20

## Mode
Settle

## Delta list
- Adds dedicated toolchain lifecycle module with separate manifest/lockfile state:
  - `:JigToolchainInstall`
  - `:JigToolchainUpdate`
  - `:JigToolchainRestore`
  - `:JigToolchainRollback`
- Adds lockfile rollback backup and managed-artifact archive path for deterministic rollback.
- Integrates toolchain drift reporting into `:JigHealth` / `:JigToolHealth`.
- Extends startup side-effect gates to assert no startup-time toolchain manifest/lockfile creation.
- Extends tools harness with deterministic fixture-based lifecycle, rollback, and drift-warning tests.

## Deliverables -> files -> verification
1) Toolchain manifest + lockfile lifecycle (separate from plugin lockfile)
- `lua/jig/tools/toolchain.lua`
- `lua/jig/tools/init.lua`
Verification:
- `nvim --headless -u NONE -l tests/run_harness.lua -- --suite tools`
- cases: `toolchain-install-restore-version-equality`, `toolchain-rollback-restores-previous-lock`

2) Explicit toolchain commands (no startup auto-update)
- `lua/jig/tools/init.lua`
- `tests/run_harness.lua`
- `.github/workflows/ci.yml`
Verification:
- startup command surface assertions in `tests/run_harness.lua`
- startup side-effect policy check in CI now asserts no auto-created toolchain files

3) Health integration + drift visibility in `:JigHealth`
- `lua/jig/tools/health.lua`
- `lua/jig/tests/tools/harness.lua`
Verification:
- case: `toolchain-drift-visible-in-health`
- case: `toolchain-drift-warning-via-jighealth`

4) Docs and command index updates
- `docs/tools.jig.nvim.md`
- `doc/jig-tools.txt`
- `docs/architecture.jig.nvim.md`
- generated command docs: `docs/commands.jig.nvim.md`, `doc/jig-commands.txt`
Verification:
- `nvim --headless -u ./init.lua '+lua package.path="./lua/?.lua;./lua/?/init.lua;"..package.path; _G.__jig_repo_root=vim.fn.getcwd(); require("jig.core.command_docs").generate({ check = true })' '+qa'`
- `nvim --headless -u NONE -l tests/run_harness.lua -- --suite docs`

## Verification commands + output summary
- `stylua --check --config-path .stylua.toml $(rg --files lua -g '*.lua')` -> pass
- `nvim --headless -u NONE -l tests/run_harness.lua -- --suite startup --suite tools --suite docs` -> pass
  - tools snapshot written with new toolchain cases
  - docs snapshot written
- `nvim --headless -u ./init.lua '+checkhealth jig' '+qa'` -> pass
- `nvim --headless -u ./init.lua '+JigHealth' '+qa'` -> pass
- `tests/check_hidden_unicode.sh` -> pass

Note: `luacheck` was unavailable in local environment; CI lane still enforces lint.

## Falsifiers + discriminating tests
1) **Falsifier:** tool install/update happens without explicit command.
- Test: startup suite + CI startup-side-effect policy now assert no startup-created `jig-toolchain-manifest.json` / `jig-toolchain-lock.json`.

2) **Falsifier:** restore cannot reproduce version probes.
- Test: `toolchain-install-restore-version-equality` mutates installed tool to drift and asserts restore returns to locked version.

3) **Falsifier:** rollback cannot restore last-known-good set in one command.
- Test: `toolchain-rollback-restores-previous-lock` updates to v2 then asserts rollback returns lock + tool binary to v1.

4) **Falsifier:** drift is not visible in health.
- Tests:
  - `toolchain-drift-visible-in-health` (`:JigToolHealth` path)
  - `toolchain-drift-warning-via-jighealth` (`:JigHealth` checkhealth path)

## Residual risks (max 7)
- System-mode tools rely on externally managed package managers; Jig does not install/upgrade them automatically.
- Managed artifact archives are local-state based; deleting state artifacts removes rollback source for managed tools.
- Version parsing is regex-based and may need per-tool adapters for unusual `--version` formats.
- `luacheck` verification depends on CI until local environment includes it.

## Rollback plan
- Revert this PR commit from `main`:
  - `git revert <merge_or_squash_sha>`
- Post-revert verification:
  - `nvim --headless -u NONE -l tests/run_harness.lua -- --suite startup --suite tools`
  - `nvim --headless -u ./init.lua '+JigHealth' '+qa'`
