### PR TITLE
docs(roadmap): reconcile wp15/wp16 boundary tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
           rg -n '"help-reference-check"' tests/docs/snapshots/latest-headless.json
           rg -n '"issue-template-failure-surfaces"' tests/docs/snapshots/latest-headless.json
           rg -n '"labels-manifest-controls"' tests/docs/snapshots/latest-headless.json
+          rg -n '"execution-board-wp16-wp17-tracking"' tests/docs/snapshots/latest-headless.json
 
       - name: LSP harness snapshot checks
         run: |

--- a/docs/roadmap/EXECUTION_BOARD.md
+++ b/docs/roadmap/EXECUTION_BOARD.md
@@ -1,7 +1,7 @@
 # EXECUTION_BOARD
 
 Generated from: `dependency roadmap (internal planning source)`
-Updated at: `2026-02-21`
+Updated at: `2026-02-26`
 
 ## Status Legend
 - `not-started`
@@ -165,8 +165,16 @@ Updated at: `2026-02-21`
   - high-severity gap without owner or falsifier test plan
 
 ### WP-16: Toolchain Lockfile and External Dependency Lifecycle
-- Status: `not-started` (`next`)
+- Status: `done`
 - Depends on: `WP-15`
 - Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/20
+- PR(s): https://github.com/Ismail-elkorchi/jig.nvim/pull/47
+- Completed at: `2026-02-26`
+- ADR(s): tbd
+
+### WP-17: Agent UX Surface, Transactional Edits, and Context Ledger
+- Status: `not-started` (`next`)
+- Depends on: `WP-16`
+- Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/21
 - PR(s): tbd
 - ADR(s): tbd

--- a/lua/jig/tests/docs/harness.lua
+++ b/lua/jig/tests/docs/harness.lua
@@ -370,6 +370,42 @@ local function keymap_docs_linked_ok()
   }
 end
 
+local function execution_board_tracking_ok()
+  local board = read_or_empty(repo_root() .. "/docs/roadmap/EXECUTION_BOARD.md")
+  assert(board ~= "", "execution board missing")
+
+  assert(
+    board:find("Updated at:%s*`%d%d%d%d%-%d%d%-%d%d`", 1, false) ~= nil,
+    "execution board missing deterministic Updated at timestamp"
+  )
+  assert(
+    board:find("### WP%-16: Toolchain Lockfile and External Dependency Lifecycle", 1, false) ~= nil,
+    "execution board missing WP-16 section"
+  )
+  assert(
+    board:find("### WP%-16:.-%- Status: `done`", 1, false) ~= nil,
+    "execution board must mark WP-16 as done"
+  )
+  assert(
+    board:find("https://github.com/Ismail%-elkorchi/jig%.nvim/pull/47", 1, false) ~= nil,
+    "execution board missing WP-16 PR reference"
+  )
+  assert(
+    board:find("### WP%-17: Agent UX Surface, Transactional Edits, and Context Ledger", 1, false)
+      ~= nil,
+    "execution board missing WP-17 section"
+  )
+  assert(
+    board:find("### WP%-17:.-%- Status: `not%-started` %(`next`%)", 1, false) ~= nil,
+    "execution board must mark WP-17 as next"
+  )
+
+  return {
+    wp16 = "done",
+    wp17 = "next",
+  }
+end
+
 local cases = {
   {
     id = "required-vimdoc-set",
@@ -425,6 +461,10 @@ local cases = {
   {
     id = "labels-manifest-controls",
     run = labels_manifest_ok,
+  },
+  {
+    id = "execution-board-wp16-wp17-tracking",
+    run = execution_board_tracking_ok,
   },
 }
 


### PR DESCRIPTION
## Scope statement
Tracking reconciliation only. No WP-17 implementation work.

## Reality audit summary (GitHub truth)
- Open PRs: `0`
- Open issues: `#21`, `#22`
- PR `#46`: already `MERGED` (`2026-02-26T00:13:53Z`)
- Issue `#20`: already `CLOSED` (manual evidence comment added in this task)
- Mismatch found: `docs/roadmap/EXECUTION_BOARD.md` still marked WP-16 `not-started`.

## Delta list
- Updated `EXECUTION_BOARD` to match repo truth:
  - WP-16 -> `done`, PR `#47`, completion date added.
  - WP-17 -> `not-started (next)`.
  - `Updated at` bumped to `2026-02-26`.
- Added deterministic docs harness guard for board drift:
  - new case `execution-board-wp16-wp17-tracking`.
- Added CI snapshot assertion for the new docs harness case.

## Deliverables -> files
- Tracking reconciliation:
  - `docs/roadmap/EXECUTION_BOARD.md`
- Guardrail:
  - `lua/jig/tests/docs/harness.lua`
  - `.github/workflows/ci.yml`

## Verification commands + output summaries
- `nvim --headless -u NONE -l tests/run_harness.lua -- --suite startup --suite tools --suite docs --suite scorecard`
  - pass; startup/tools/docs/scorecard snapshots written.
- `scripts/wp15/check_research_done.lua`
  - `wp15 research check passed: baselines=14 evidence=71 domains=26`
- `scripts/wp15/check_gaps.lua`
  - `wp15 gaps check passed: gaps=7`
- `tests/check_hidden_unicode.sh`
  - `hidden/bidi unicode gate passed`

## Falsifiers checked
1) **Board stale after merged WP**
- Check: docs harness case `execution-board-wp16-wp17-tracking` fails if WP-16 not marked done with PR ref.
2) **Docs harness case silently removed**
- Check: CI docs step now greps for `execution-board-wp16-wp17-tracking` in snapshot.

## Residual risks
- This guard is boundary-specific (WP-16/WP-17) and not a full generalized board-vs-git consistency engine.
- Future WP transitions require updating this harness case expectations.
