### PR TITLE
fix(docs): reconcile wp17 board state and tracking guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
           rg -n '"help-reference-check"' tests/docs/snapshots/latest-headless.json
           rg -n '"issue-template-failure-surfaces"' tests/docs/snapshots/latest-headless.json
           rg -n '"labels-manifest-controls"' tests/docs/snapshots/latest-headless.json
-          rg -n '"execution-board-wp16-wp17-tracking"' tests/docs/snapshots/latest-headless.json
+          rg -n '"execution-board-wp16-wp18-tracking"' tests/docs/snapshots/latest-headless.json
 
       - name: LSP harness snapshot checks
         run: |

--- a/docs/roadmap/EXECUTION_BOARD.md
+++ b/docs/roadmap/EXECUTION_BOARD.md
@@ -173,8 +173,16 @@ Updated at: `2026-02-26`
 - ADR(s): tbd
 
 ### WP-17: Agent UX Surface, Transactional Edits, and Context Ledger
-- Status: `not-started` (`next`)
+- Status: `done`
 - Depends on: `WP-16`
 - Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/21
+- PR(s): https://github.com/Ismail-elkorchi/jig.nvim/pull/49
+- Completed at: `2026-02-26`
+- ADR(s): tbd
+
+### WP-18: Agent Threat Model and Security Regression Suite
+- Status: `not-started` (`next`)
+- Depends on: `WP-17`
+- Issue: https://github.com/Ismail-elkorchi/jig.nvim/issues/22
 - PR(s): tbd
 - ADR(s): tbd

--- a/lua/jig/tests/docs/harness.lua
+++ b/lua/jig/tests/docs/harness.lua
@@ -396,13 +396,26 @@ local function execution_board_tracking_ok()
     "execution board missing WP-17 section"
   )
   assert(
-    board:find("### WP%-17:.-%- Status: `not%-started` %(`next`%)", 1, false) ~= nil,
-    "execution board must mark WP-17 as next"
+    board:find("### WP%-17:.-%- Status: `done`", 1, false) ~= nil,
+    "execution board must mark WP-17 as done"
+  )
+  assert(
+    board:find("https://github.com/Ismail%-elkorchi/jig%.nvim/pull/49", 1, false) ~= nil,
+    "execution board missing WP-17 PR reference"
+  )
+  assert(
+    board:find("### WP%-18: Agent Threat Model and Security Regression Suite", 1, false) ~= nil,
+    "execution board missing WP-18 section"
+  )
+  assert(
+    board:find("### WP%-18:.-%- Status: `not%-started` %(`next`%)", 1, false) ~= nil,
+    "execution board must mark WP-18 as next"
   )
 
   return {
     wp16 = "done",
-    wp17 = "next",
+    wp17 = "done",
+    wp18 = "next",
   }
 end
 
@@ -463,7 +476,7 @@ local cases = {
     run = labels_manifest_ok,
   },
   {
-    id = "execution-board-wp16-wp17-tracking",
+    id = "execution-board-wp16-wp18-tracking",
     run = execution_board_tracking_ok,
   },
 }


### PR DESCRIPTION
## Mode
Settle

## Why
Repository tracking drift existed: `docs/roadmap/EXECUTION_BOARD.md` still marked WP-17 as `not-started` after merged PR #49.

## Reality check evidence (Phase 0)
- `gh pr view 49 --json state,mergedAt,url,title` -> `state=MERGED`, `mergedAt=2026-02-26T02:44:34Z`.
- `gh issue view 20 --json state,url,title` -> `state=CLOSED`.
- `gh issue view 21 --json state,url,title` -> `state=CLOSED`.
- `gh pr view 46 --json state,mergedAt,url,title` -> `state=MERGED` (not open/superseded).
- `gh pr list --state open` (before this PR) -> no open PRs.
- `docs/roadmap/EXECUTION_BOARD.md` had WP-17 marked `not-started`.

## Delta list
- Update execution board to reflect WP-17 done with PR #49 reference.
- Add WP-18 section as `not-started` (`next`) with issue #22.
- Update deterministic docs harness + CI assertion id so board drift is caught offline in future runs.

## Deliverable -> files
- Board reconciliation:
  - `docs/roadmap/EXECUTION_BOARD.md`
- Deterministic enforcement:
  - `lua/jig/tests/docs/harness.lua`
  - `.github/workflows/ci.yml`

## Verification commands run
- `stylua --check --config-path .stylua.toml $(rg --files lua -g '*.lua')`
- `nvim --headless -u NONE -l tests/run_harness.lua -- --suite startup --suite tools --suite docs --suite scorecard`
- `scripts/wp15/check_research_done.lua`
- `scripts/wp15/check_gaps.lua`
- `tests/check_hidden_unicode.sh`

All commands passed locally.

## Falsifiers checked
- Board drift recurrence: docs harness case now requires `WP-17 done` + PR #49 and `WP-18 next`.
- CI drift guard presence: workflow checks snapshot for `execution-board-wp16-wp18-tracking`.

## Scope
Tracking reconciliation only. No WP-18 implementation.
