### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ NVIM_APPNAME=jig-safe nvim
 
 ## Commands
 - `:JigHealth` run distro + provider health checks.
+- `:JigVersion` print deterministic support report (Jig commit, Neovim version, OS, channel, stdpaths).
 - `:JigVerboseMap {lhs}` show keymap provenance.
 - `:JigVerboseSet {option}` show option provenance.
 - `:JigBisectGuide` print deterministic bisect guidance.
@@ -117,6 +118,8 @@ tests/perf/run_harness.sh
 ```
 
 ## Documentation
+- `SECURITY.md`
+- `SUPPORT.md`
 - `docs/install.jig.nvim.md`
 - `docs/contract.jig.nvim.md`
 - `docs/keymaps.jig.nvim.md`
@@ -143,6 +146,11 @@ tests/perf/run_harness.sh
 - `doc/jig-security.txt` (`:help jig-security`)
 - `doc/jig-platform.txt` (`:help jig-platform`)
 - `doc/jig-testing.txt` (`:help jig-testing`)
+
+## Support and Security
+- Support workflow: `SUPPORT.md`
+- Security disclosure policy: `SECURITY.md`
+- Security controls and boundaries: `docs/security.jig.nvim.md` and `:help jig-security`
 
 ## License
 MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+Jig uses a **containment-first** security posture:
+- deny/ask/allow policy gates for risky operations
+- explicit audit logging and attribution
+- deterministic security regression tests
+
+Jig does **not** claim perfect prevention. See `docs/security.jig.nvim.md` and `:help jig-security` for boundaries and current threat model coverage.
+
+## Reporting a Vulnerability
+
+Preferred channel (private):
+- GitHub Security Advisory draft:  
+  `https://github.com/Ismail-elkorchi/jig.nvim/security/advisories/new`
+
+Fallback (if advisory flow is unavailable):
+- Open a GitHub issue with `security` failure surface using the incident template:
+  `https://github.com/Ismail-elkorchi/jig.nvim/issues/new/choose`
+
+## What to include
+
+- affected Jig version/commit (`:JigVersion`)
+- Neovim version and OS (`:JigVersion`)
+- exact reproduction steps
+- expected vs actual behavior
+- minimal proof-of-concept (non-destructive)
+
+## Scope and boundaries
+
+- No guarantee of protection against every prompt-injection or remote-server integrity risk.
+- Security controls are only as strong as user policy decisions and local runtime environment.
+- `NVIM_APPNAME=jig-safe` is the recommended recovery profile for incident triage.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,47 @@
+# Support
+
+Jig support is issue-driven and evidence-first. Use the GitHub issue templates:
+- `https://github.com/Ismail-elkorchi/jig.nvim/issues/new/choose`
+
+Canonical docs:
+- `docs/troubleshooting.jig.nvim.md` (`:help jig-troubleshooting`)
+- `docs/runbooks/INCIDENTS.md`
+- `docs/runbooks/ROLLBACK.md`
+
+## Before opening an issue
+
+Run and attach outputs:
+
+```bash
+nvim --version
+nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
+nvim --headless -u ./init.lua '+JigHealth' '+qa'
+nvim --headless -u ./init.lua '+JigVersion' '+qa'
+NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+JigVersion' '+qa'
+```
+
+If startup is unstable:
+
+```bash
+NVIM_APPNAME=jig-safe nvim -u ./init.lua
+nvim --startuptime /tmp/jig.startuptime.log -u ./init.lua '+qa'
+```
+
+## Failure-surface triage
+
+Classify the report under one failure surface:
+- startup
+- cmdline
+- completion
+- lsp
+- ui
+- performance
+- platform
+- integration
+- agent
+- security
+
+## Boundaries
+
+- Support guidance does not guarantee compatibility with every terminal/font/plugin combination.
+- Recovery instructions prioritize deterministic rollback and minimal profile isolation.

--- a/doc/jig-commands.txt
+++ b/doc/jig-commands.txt
@@ -40,6 +40,7 @@ COMMANDS
   :JigUiProfile       optional-one Set accessibility profile (default|high-contrast|reduced-decoration|reduced-motion)
   :JigVerboseMap      one          Show keymap provenance via :verbose map <lhs>
   :JigVerboseSet      one          Show option provenance via :verbose set <option>?
+  :JigVersion         none         Print deterministic Jig/Neovim/environment support report
 
 BOUNDARIES
   This file covers default-profile commands. Optional agent commands are

--- a/doc/jig.txt
+++ b/doc/jig.txt
@@ -31,6 +31,9 @@ COMMAND DISCOVERY
   :JigRepro
       Print deterministic minimal repro workflow.
 
+  :JigVersion
+      Print deterministic support report (commit/profile/channel/stdpaths).
+
 NOT GUARANTEED / BOUNDARIES
   - Jig documents default behavior and explicit optional features.
   - Optional modules are not guaranteed in `NVIM_APPNAME=jig-safe`.

--- a/docs/commands.jig.nvim.md
+++ b/docs/commands.jig.nvim.md
@@ -41,6 +41,7 @@ Generated from the default runtime command surface. Do not edit manually.
 | `:JigUiProfile` | `optional-one` | `no` | Set accessibility profile (default|high-contrast|reduced-decoration|reduced-motion) |
 | `:JigVerboseMap` | `one` | `no` | Show keymap provenance via :verbose map <lhs> |
 | `:JigVerboseSet` | `one` | `no` | Show option provenance via :verbose set <option>? |
+| `:JigVersion` | `none` | `no` | Print deterministic Jig/Neovim/environment support report |
 
 Canonical help: `:help jig-commands`
 

--- a/lua/jig/core/doctor.lua
+++ b/lua/jig/core/doctor.lua
@@ -126,7 +126,15 @@ end
 local function collect_version_report()
   local root = repo_root()
   local version = vim.version()
-  local uname = (vim.uv or vim.loop).os_uname()
+  local uname = {
+    sysname = "",
+    release = "",
+    machine = "",
+  }
+  local ok_uname, detected_uname = pcall(vim.uv.os_uname)
+  if ok_uname and type(detected_uname) == "table" then
+    uname = detected_uname
+  end
   local commit, commit_source = resolve_head_sha(root)
   local channel = channel_state.load()
 

--- a/lua/jig/core/doctor.lua
+++ b/lua/jig/core/doctor.lua
@@ -1,4 +1,5 @@
 local brand = require("jig.core.brand")
+local channel_state = require("jig.core.channel")
 
 local M = {}
 
@@ -34,6 +35,162 @@ local function cmd_bisect_guide()
   )
 end
 
+local function repo_root()
+  local source = debug.getinfo(1, "S").source
+  if vim.startswith(source, "@") then
+    source = source:sub(2)
+  end
+  return vim.fn.fnamemodify(source, ":p:h:h:h:h")
+end
+
+local function resolve_git_dir(root)
+  local dotgit = vim.fs.joinpath(root, ".git")
+  if vim.fn.isdirectory(dotgit) == 1 then
+    return vim.fs.normalize(dotgit), "git_dir"
+  end
+
+  if vim.fn.filereadable(dotgit) ~= 1 then
+    return nil, "missing_dotgit"
+  end
+
+  local first_line = (vim.fn.readfile(dotgit)[1] or "")
+  local target = first_line:match("^gitdir:%s*(.+)%s*$")
+  if target == nil then
+    return nil, "invalid_git_pointer"
+  end
+
+  if vim.fs.isabspath(target) then
+    return vim.fs.normalize(target), "gitdir_pointer"
+  end
+
+  return vim.fs.normalize(vim.fs.joinpath(root, target)), "gitdir_pointer"
+end
+
+local function read_ref_from_packed_refs(git_dir, ref_name)
+  local packed = vim.fs.joinpath(git_dir, "packed-refs")
+  if vim.fn.filereadable(packed) ~= 1 then
+    return nil
+  end
+
+  for _, line in ipairs(vim.fn.readfile(packed)) do
+    if line ~= "" and not vim.startswith(line, "#") and not vim.startswith(line, "^") then
+      local hash, name = line:match("^(%x+)%s+(.+)$")
+      if hash ~= nil and name == ref_name then
+        return hash
+      end
+    end
+  end
+
+  return nil
+end
+
+local function resolve_head_sha(root)
+  local git_dir, git_source = resolve_git_dir(root)
+  if git_dir == nil then
+    return "unknown", git_source
+  end
+
+  local head_path = vim.fs.joinpath(git_dir, "HEAD")
+  if vim.fn.filereadable(head_path) ~= 1 then
+    return "unknown", "missing_head"
+  end
+
+  local head_line = vim.trim(vim.fn.readfile(head_path)[1] or "")
+  if head_line == "" then
+    return "unknown", "empty_head"
+  end
+
+  local ref_name = head_line:match("^ref:%s*(.+)$")
+  if ref_name ~= nil then
+    local ref_file = vim.fs.joinpath(git_dir, ref_name)
+    local hash = nil
+    if vim.fn.filereadable(ref_file) == 1 then
+      hash = vim.trim(vim.fn.readfile(ref_file)[1] or "")
+    end
+    if hash == nil or hash == "" then
+      hash = read_ref_from_packed_refs(git_dir, ref_name)
+    end
+    if hash ~= nil and hash ~= "" then
+      return hash:sub(1, 12), ref_name
+    end
+    return "unknown", "unresolved_ref"
+  end
+
+  if head_line:match("^[0-9a-fA-F]+$") then
+    return head_line:sub(1, 12), "detached_head"
+  end
+
+  return "unknown", "invalid_head"
+end
+
+local function collect_version_report()
+  local root = repo_root()
+  local version = vim.version()
+  local uname = (vim.uv or vim.loop).os_uname()
+  local commit, commit_source = resolve_head_sha(root)
+  local channel = channel_state.load()
+
+  return {
+    jig = {
+      brand = brand.brand,
+      commit = commit,
+      commit_source = commit_source,
+      profile = tostring(vim.g.jig_profile or "unknown"),
+      appname = tostring(vim.g.jig_appname or vim.env.NVIM_APPNAME or "nvim"),
+    },
+    neovim = string.format("%d.%d.%d", version.major, version.minor, version.patch),
+    os = {
+      sysname = tostring(uname.sysname or ""),
+      release = tostring(uname.release or ""),
+      machine = tostring(uname.machine or ""),
+    },
+    channel = {
+      value = tostring(channel.channel or channel_state.default()),
+      source = tostring(channel.source or "default"),
+      path = tostring(channel.path or channel_state.path()),
+      error = channel.error and tostring(channel.error) or nil,
+    },
+    stdpath = {
+      config = vim.fn.stdpath("config"),
+      data = vim.fn.stdpath("data"),
+      state = vim.fn.stdpath("state"),
+      cache = vim.fn.stdpath("cache"),
+    },
+  }
+end
+
+local function cmd_version()
+  local report = collect_version_report()
+  vim.g.jig_version_last = report
+
+  local lines = {
+    string.format("%s Version Report", report.jig.brand),
+    string.rep("=", 18),
+    string.format("jig.commit=%s", report.jig.commit),
+    string.format("jig.commit_source=%s", report.jig.commit_source),
+    string.format("jig.profile=%s", report.jig.profile),
+    string.format("jig.appname=%s", report.jig.appname),
+    string.format("neovim.version=%s", report.neovim),
+    string.format("os=%s %s (%s)", report.os.sysname, report.os.release, report.os.machine),
+    string.format(
+      "channel=%s (source=%s path=%s)",
+      report.channel.value,
+      report.channel.source,
+      report.channel.path
+    ),
+    string.format("stdpath.config=%s", report.stdpath.config),
+    string.format("stdpath.data=%s", report.stdpath.data),
+    string.format("stdpath.state=%s", report.stdpath.state),
+    string.format("stdpath.cache=%s", report.stdpath.cache),
+  }
+
+  if report.channel.error ~= nil then
+    lines[#lines + 1] = string.format("channel.error=%s", report.channel.error)
+  end
+
+  print(table.concat(lines, "\n"))
+end
+
 function M.setup()
   -- boundary: allow-vim-api
   -- Justification: user command registration is a Neovim host boundary operation.
@@ -53,6 +210,10 @@ function M.setup()
 
   vim.api.nvim_create_user_command(brand.command("BisectGuide"), cmd_bisect_guide, {
     desc = "Show deterministic bisect guidance",
+  })
+
+  vim.api.nvim_create_user_command(brand.command("Version"), cmd_version, {
+    desc = "Print deterministic Jig/Neovim/environment support report",
   })
 end
 

--- a/lua/jig/tests/docs/harness.lua
+++ b/lua/jig/tests/docs/harness.lua
@@ -358,6 +358,26 @@ local function repro_command_ok()
   }
 end
 
+local function version_command_ok()
+  assert(vim.fn.exists(":JigVersion") == 2, "JigVersion command missing")
+  vim.cmd("JigVersion")
+  local payload = vim.g.jig_version_last
+  assert(type(payload) == "table", "JigVersion payload missing")
+  assert(type(payload.jig) == "table", "JigVersion payload.jig missing")
+  assert(type(payload.channel) == "table", "JigVersion payload.channel missing")
+  assert(type(payload.stdpath) == "table", "JigVersion payload.stdpath missing")
+  assert(type(payload.neovim) == "string" and payload.neovim ~= "", "JigVersion neovim missing")
+  assert(
+    type(payload.stdpath.config) == "string" and payload.stdpath.config ~= "",
+    "stdpath config missing"
+  )
+  assert(type(payload.channel.value) == "string" and payload.channel.value ~= "", "channel missing")
+  return {
+    profile = payload.jig.profile,
+    channel = payload.channel.value,
+  }
+end
+
 local function keymap_docs_linked_ok()
   assert(keymap_docs.generate({ check = true }), "keymap docs out of sync")
   local index = read_or_empty(repo_root() .. "/docs/index.jig.nvim.md")
@@ -435,6 +455,10 @@ local cases = {
   {
     id = "repro-command-surface",
     run = repro_command_ok,
+  },
+  {
+    id = "version-command-surface",
+    run = version_command_ok,
   },
   {
     id = "command-doc-sync-gate",

--- a/tests/run_harness.lua
+++ b/tests/run_harness.lua
@@ -61,6 +61,7 @@ local function run_startup_smoke()
   assert(vim.fn.exists(":JigKeys") == 2, "JigKeys missing")
   assert(vim.fn.exists(":JigFiles") == 2, "JigFiles missing")
   assert(vim.fn.exists(":JigExec") == 2, "JigExec missing")
+  assert(vim.fn.exists(":JigVersion") == 2, "JigVersion missing")
   assert(vim.fn.exists(":JigToolchainInstall") == 2, "JigToolchainInstall missing")
   assert(vim.fn.exists(":JigToolchainUpdate") == 2, "JigToolchainUpdate missing")
   assert(vim.fn.exists(":JigToolchainRestore") == 2, "JigToolchainRestore missing")
@@ -99,6 +100,29 @@ local function run_startup_smoke()
     vim.fn.filereadable(tmp .. "/config/jig-ci/jig-toolchain-lock.json") == 0,
     "startup auto-created toolchain lockfile"
   )
+
+  local safe_env = vim.fn.deepcopy(env)
+  safe_env.NVIM_APPNAME = "jig-safe"
+  local safe_result = vim
+    .system({
+      "nvim",
+      "--headless",
+      "-u",
+      join(ROOT, "init.lua"),
+      "+lua assert(vim.g.jig_profile=='safe','safe profile expected')",
+      "+lua assert(vim.fn.exists(':JigVersion')==2,'JigVersion missing in safe profile')",
+      "+JigVersion",
+      "+qa",
+    }, {
+      env = safe_env,
+      text = true,
+    })
+    :wait(10000)
+  assert(
+    safe_result ~= nil and safe_result.code == 0,
+    "safe profile version command failed: " .. tostring(safe_result and safe_result.stderr or "nil")
+  )
+
   vim.fn.delete(tmp, "rf")
 
   return {


### PR DESCRIPTION
## Why
- Problem statement: Jig defines `stable` as tag-based release policy but had no published GitHub release or top-level support/security surfaces.
- User impact: Users lacked a canonical first stable artifact (`v0.1.0`) and a deterministic command to attach environment/version evidence in bug/security reports.

## What
- Summary of change:
  - Adds top-level `SECURITY.md` with responsible disclosure path + explicit boundaries.
  - Adds top-level `SUPPORT.md` with required evidence commands and safe-profile recovery path.
  - Adds `:JigVersion` (in `lua/jig/core/doctor.lua`) with deterministic report output: Jig commit ID, Neovim version, OS, channel state, and `stdpath` summary.
  - Extends tests to prove `:JigVersion` exists in default and `jig-safe` profiles and is documented.
  - Regenerates command docs (`docs/commands.jig.nvim.md`, `doc/jig-commands.txt`) and updates `README.md` + `doc/jig.txt` links.

## Roadmap Linkage
- Work package(s): Stewardship Phase 2 Step 1 (first stable release operability), no new roadmap WP.
- Requirement IDs: release operability constraints from user instruction (no new feature drift; deterministic evidence; rollback-ready).

## Mode Declaration
- Mode: `Settle`
- Reason: shipping first stable release surface with explicit gates and no exploratory behavior changes.

## Repo Truth Audit (Step 0)
- Open PRs before this PR: `0` (`gh pr list --state open --json number,title --jq 'length'`)
- Open issues before this PR: `0` (`gh issue list --state open --json number,title --jq 'length'`)
- `origin/main` commit SHA before branch: `89a8c43c9e2e163902b2acc26e14e39e74d79110`

## Evidence
- [x] local smoke (`nvim --headless -u ./init.lua '+qa'`)
- [x] local health (`nvim --headless -u ./init.lua '+checkhealth jig' '+qa'`)
- [ ] CI checks pass
- Commands + output summary:
  ```bash
  stylua --check --config-path .stylua.toml $(rg --files lua tests -g '*.lua')
  nvim --headless -u NONE -l tests/run_harness.lua -- --all
  tests/ops/run_harness.sh
  tests/perf/run_harness.sh
  tests/check_hidden_unicode.sh
  scripts/wp15/check_research_done.lua
  scripts/wp15/check_gaps.lua
  tests/security/run_harness.sh
  nvim --headless -u ./init.lua '+checkhealth jig' '+qa'
  NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+JigVersion' '+qa'
  nvim --headless -u NONE -l tests/docs/update_helptags.lua
  git diff --exit-code -- doc/tags
  ```
  - Result summary: all commands above exit `0`; docs/startup/security/perf/ops/scorecard suites pass; hidden Unicode gate passes; `:JigVersion` outputs deterministic report in `jig-safe`.

## Failure Modes and Residual Risk
1. Failure mode: `:JigVersion` missing or broken in `jig-safe`.
   - Discriminating check: startup harness includes safe subprocess assertions and explicit `+JigVersion` execution.
2. Failure mode: command/docs drift leaves new command undocumented.
   - Discriminating check: docs harness command cross-reference + `command_docs.generate({ check = true })` gate.
3. Falsifier check: release-operability patch causes startup side-effects (install/network/state mutation).
   - Discriminating check: existing startup smoke + ops/security harnesses still pass unchanged.

Residual risk:
- Commit ID resolution is filesystem-based (`.git` metadata) and can return `unknown` for archive/source-distribution installs.
- OS summary reflects local runtime (`os_uname`) and not container/remote host topology details.
- Support/security docs require maintainer responsiveness; automation cannot enforce response SLAs.

## Rollback Plan
- Revert command(s):
  ```bash
  git revert 1e84ddd e47258f
  ```
- Rollback notes:
  - Reverting this commit removes `SECURITY.md`, `SUPPORT.md`, and `:JigVersion` while preserving prior runtime behavior.
  - No data migrations or lockfile changes are introduced in this PR.

## Docs and Security Impact
- Docs changed:
  - `README.md`
  - `SECURITY.md`
  - `SUPPORT.md`
  - `doc/jig.txt`
  - `docs/commands.jig.nvim.md`
  - `doc/jig-commands.txt`
- Network/exec/filesystem/policy impact:
  - No startup network behavior changes.
  - No startup auto-install/update behavior changes.
  - `:JigVersion` is read-only and does not modify state.

## Release Notes Draft (`v0.1.0`)
### Highlights
- First stable Jig release `v0.1.0` published with explicit `stable=tag` policy execution.
- Added `:JigVersion` for deterministic support/security report collection.
- Added top-level `SECURITY.md` and `SUPPORT.md` for disclosure and incident triage workflows.

### Boundaries
- No default behavior changes to startup/install/network policies.
- Optional modules remain opt-in; `NVIM_APPNAME=jig-safe` remains isolated.

### Known limitations
- `:JigVersion` may report `jig.commit=unknown` in non-git source archives.

### Rollback
- Use `docs/runbooks/ROLLBACK.md` and `:JigPluginRollback` / safe profile recovery path.

