### PR TITLE
feat(workbench): dogfooding workbench mode + harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainUpdate")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRestore")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRollback")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbench")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbenchReset")==2)' '+qa'
+          nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbenchHelp")==2)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpTrust")==0)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpList")==0)' '+qa'
           nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigAgentContext")==0)' '+qa'
@@ -192,6 +195,9 @@ jobs:
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainUpdate")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRestore")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigToolchainRollback")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbench")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbenchReset")==0)' '+qa'
+          NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbenchHelp")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpTrust")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigMcpList")==0)' '+qa'
           NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigAgentContext")==0)' '+qa'
@@ -274,6 +280,7 @@ jobs:
           rg -n '"markdown-link-check"' tests/docs/snapshots/latest-headless.json
           rg -n '"help-reference-check"' tests/docs/snapshots/latest-headless.json
           rg -n '"issue-template-failure-surfaces"' tests/docs/snapshots/latest-headless.json
+          rg -n '"workbench-doc-research-gate"' tests/docs/snapshots/latest-headless.json
           rg -n '"labels-manifest-controls"' tests/docs/snapshots/latest-headless.json
           rg -n '"execution-board-wp16-wp18-tracking"' tests/docs/snapshots/latest-headless.json
 
@@ -298,6 +305,18 @@ jobs:
           rg -n '"toolchain-drift-visible-in-health"' tests/tools/snapshots/latest-headless.json
           rg -n '"toolchain-drift-warning-via-jighealth"' tests/tools/snapshots/latest-headless.json
           rg -n '"safe-profile-isolation"' tests/tools/snapshots/latest-headless.json
+
+      - name: Workbench harness snapshot checks
+        run: |
+          tests/workbench/run_harness.sh
+          test -f tests/workbench/snapshots/latest-headless.json
+          rg -n '"research-done-r1-r5-gate"' tests/workbench/snapshots/latest-headless.json
+          rg -n '"workbench-help-command-surface"' tests/workbench/snapshots/latest-headless.json
+          rg -n '"dev-preset-idempotent-layout"' tests/workbench/snapshots/latest-headless.json
+          rg -n '"review-preset-git-surface"' tests/workbench/snapshots/latest-headless.json
+          rg -n '"minimal-preset-no-terminal"' tests/workbench/snapshots/latest-headless.json
+          rg -n '"agent-preset-enabled-panel"' tests/workbench/snapshots/latest-headless.json
+          rg -n '"safe-profile-isolation"' tests/workbench/snapshots/latest-headless.json
 
       - name: Agent harness snapshot checks
         run: |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ NVIM_APPNAME=jig-safe nvim
 - `:JigExec! {cmd...}` user-only destructive override path (visible warning + audit log).
 - `:JigToolHealth` show shell/provider/tool integration summary.
 - `:JigTerm [root|buffer]` open integrated terminal in Jig root (or current buffer directory).
+- `:JigWorkbench [preset]` assemble an idempotent daily-driver layout (`dev|review|agent|minimal`).
+- `:JigWorkbenchReset` reset workbench role panes in the current tab.
+- `:JigWorkbenchHelp` open workbench help topic.
 - `:JigMcpList` list discovered MCP servers (when agent module enabled).
 - `:JigMcpTrust` list MCP trust state/capabilities and update allow/ask/deny/revoke.
 - `:JigMcpStart <server>` start MCP handshake for one server (when enabled).
@@ -128,6 +131,7 @@ tests/perf/run_harness.sh
 - `docs/plugin-manager.jig.nvim.md`
 - `docs/profiling.jig.nvim.md`
 - `docs/navigation.jig.nvim.md`
+- `docs/workbench.jig.nvim.md`
 - `docs/lsp.jig.nvim.md`
 - `docs/tools.jig.nvim.md`
 - `docs/agents.jig.nvim.md`
@@ -140,7 +144,9 @@ tests/perf/run_harness.sh
 - `docs/stability.jig.nvim.md`
 - `docs/compatibility.jig.nvim.md`
 - `docs/troubleshooting.jig.nvim.md`
+- `docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md`
 - `doc/jig-lsp.txt` (`:help jig-lsp`)
+- `doc/jig-workbench.txt` (`:help jig-workbench`)
 - `doc/jig-tools.txt` (`:help jig-tools`)
 - `doc/jig-agents.txt` (`:help jig-agents`)
 - `doc/jig-security.txt` (`:help jig-security`)

--- a/doc/jig-commands.txt
+++ b/doc/jig-commands.txt
@@ -41,6 +41,9 @@ COMMANDS
   :JigVerboseMap      one          Show keymap provenance via :verbose map <lhs>
   :JigVerboseSet      one          Show option provenance via :verbose set <option>?
   :JigVersion         none         Print deterministic Jig/Neovim/environment support report
+  :JigWorkbench       optional-one Assemble an idempotent workbench layout (dev|review|agent|minimal)
+  :JigWorkbenchHelp   none         Open workbench help topic
+  :JigWorkbenchReset  none         Reset workbench layout roles in current tab
 
 BOUNDARIES
   This file covers default-profile commands. Optional agent commands are

--- a/doc/jig-workbench.txt
+++ b/doc/jig-workbench.txt
@@ -1,0 +1,47 @@
+*jig-workbench*  Jig Workbench Mode
+
+OVERVIEW
+  Workbench Mode assembles an explicit, repeatable, IDE-like session layout
+  on demand. It does not run automatically at startup.
+
+COMMANDS
+  :JigWorkbench [dev|review|agent|minimal]
+      Assemble workbench layout for selected preset.
+
+  :JigWorkbenchReset
+      Close workbench role panes (nav/term/agent) and clear role state.
+
+  :JigWorkbenchHelp
+      Open this help topic. If help tags are unavailable, opens |:JigDocs|
+      fallback index.
+
+PRESETS
+  dev
+      nav(files) + main + terminal
+  review
+      nav(git changes) + main + terminal
+  agent
+      nav(files) + main + terminal + agent queue panel
+      (agent panel appears only when agent module is enabled)
+  minimal
+      nav(files) + main
+
+FIRST 10 MINUTES
+  1. :JigWorkbench dev
+  2. edit in center pane; navigate from left pane
+  3. run tests/tasks in terminal pane
+  4. :JigWorkbench review before commit
+  5. :JigWorkbenchReset when pane drift appears
+
+SAFE PROFILE
+  NVIM_APPNAME=jig-safe does not expose workbench commands.
+
+BOUNDARIES
+  - No startup auto-install/update behavior.
+  - No startup implicit network behavior.
+  - Native cmdline path remains default.
+
+SEE ALSO
+  |jig| |jig-commands| |jig-tools| |jig-agents| |jig-security|
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/jig.txt
+++ b/doc/jig.txt
@@ -9,8 +9,10 @@ START HERE
   |jig-configuration|   profile/config boundaries
   |jig-commands|        default :Jig* command index
   |jig-keymaps|         default keymap registry output
+  |jig-workbench|       single-entry workbench presets for daily loops
 
 OPERATIONS
+  |jig-workbench|       workbench mode presets and reset path
   |jig-troubleshooting| recurring failure classes + next commands
   |jig-migration|       migration checklist and rollback path
   |jig-release|         release checklist and channel publication workflow
@@ -30,6 +32,9 @@ COMMAND DISCOVERY
 
   :JigRepro
       Print deterministic minimal repro workflow.
+
+  :JigWorkbench [preset]
+      Assemble an idempotent dogfooding layout (`dev|review|agent|minimal`).
 
   :JigVersion
       Print deterministic support report (commit/profile/channel/stdpaths).

--- a/doc/tags
+++ b/doc/tags
@@ -22,3 +22,4 @@ jig-testing-scorecard	jig-testing.txt	/*jig-testing-scorecard*
 jig-testing-snapshots	jig-testing.txt	/*jig-testing-snapshots*
 jig-tools	jig-tools.txt	/*jig-tools*
 jig-troubleshooting	jig-troubleshooting.txt	/*jig-troubleshooting*
+jig-workbench	jig-workbench.txt	/*jig-workbench*

--- a/docs/architecture.jig.nvim.md
+++ b/docs/architecture.jig.nvim.md
@@ -43,6 +43,9 @@ Canonical help: `:help jig`
 - `tools/toolchain.lua`: manifest+lockfile lifecycle for external toolchain install/update/restore/rollback and drift reporting.
 - `tools/health.lua`: shell/provider/tool health summaries and checkhealth integration.
 - `tools/init.lua`: command orchestration + `:JigExec`, `:JigToolHealth`, `:JigTerm`, and `:JigToolchain*` lifecycle commands.
+- `workbench/config.lua`: workbench preset policy and tunables.
+- `workbench/init.lua`: idempotent workbench layout orchestration + `:JigWorkbench*` commands.
+- `workbench/research_check.lua`: deterministic R1–R5 research truth-condition checker.
 - `security/config.lua`: runtime security policy defaults + override merge.
 - `security/startup_phase.lua`: startup phase boundary tracking (`startup` -> `done`).
 - `security/net_guard.lua`: startup network classification, deny-by-default, and trace hooks.
@@ -85,6 +88,7 @@ Canonical help: `:help jig`
 - `lua/jig/tests/perf/harness.lua`: deterministic perf probes and extreme-regression budgets.
 - `lua/jig/tests/ops/harness.lua`: release/rollback/incident operations drill suite.
 - `lua/jig/tests/agent_ui/harness.lua`: WP-17 approval/pipeline/context/instruction UX regression suite.
+- `lua/jig/tests/workbench/harness.lua`: workbench layout/idempotence/safe-profile/research-gate regression suite.
 
 ## Policy
 - Stability-first defaults.

--- a/docs/commands.jig.nvim.md
+++ b/docs/commands.jig.nvim.md
@@ -42,6 +42,9 @@ Generated from the default runtime command surface. Do not edit manually.
 | `:JigVerboseMap` | `one` | `no` | Show keymap provenance via :verbose map <lhs> |
 | `:JigVerboseSet` | `one` | `no` | Show option provenance via :verbose set <option>? |
 | `:JigVersion` | `none` | `no` | Print deterministic Jig/Neovim/environment support report |
+| `:JigWorkbench` | `optional-one` | `no` | Assemble an idempotent workbench layout (dev|review|agent|minimal) |
+| `:JigWorkbenchHelp` | `none` | `no` | Open workbench help topic |
+| `:JigWorkbenchReset` | `none` | `no` | Reset workbench layout roles in current tab |
 
 Canonical help: `:help jig-commands`
 

--- a/docs/index.jig.nvim.md
+++ b/docs/index.jig.nvim.md
@@ -6,9 +6,10 @@ Canonical in-editor entrypoint: `:help jig`
 
 ## First 15 Minutes
 1. Install and isolate: [install.jig.nvim.md](install.jig.nvim.md) and `:help jig-install`
-2. Verify runtime: `:checkhealth jig` and `:JigHealth`
-3. Discover commands: `:JigDocs` and `:help jig-commands`
-4. Discover keymaps: `:JigKeys` and `:help jig-keymaps`
+2. Verify runtime: `:checkhealth jig`, `:JigHealth`, and `:JigVersion`
+3. Start one-command daily layout: `:JigWorkbench dev` and `:help jig-workbench`
+4. Discover command surfaces: `:JigDocs` and `:help jig-commands`
+5. Discover keymaps: `:JigKeys` and `:help jig-keymaps`
 
 ## If Something Breaks
 1. Open safe profile: `NVIM_APPNAME=jig-safe nvim`
@@ -21,6 +22,7 @@ Canonical in-editor entrypoint: `:help jig`
 - Install: `:help jig-install`
 - Configuration: `:help jig-configuration`
 - Commands: `:help jig-commands`
+- Workbench: `:help jig-workbench`
 - Keymaps: `:help jig-keymaps`
 - Troubleshooting: `:help jig-troubleshooting`
 - Migration: `:help jig-migration`
@@ -34,6 +36,8 @@ Canonical in-editor entrypoint: `:help jig`
 - Platform: `:help jig-platform`
 - Testing: `:help jig-testing`
 - Agents (optional): `:help jig-agents`
+- Workbench design notes: [workbench.jig.nvim.md](workbench.jig.nvim.md)
+- Neovim roadmap alignment: [roadmap/NEOVIM_ROADMAP_ALIGNMENT.md](roadmap/NEOVIM_ROADMAP_ALIGNMENT.md)
 
 ## Maintainer runbooks
 - Release checklist: [runbooks/RELEASE.md](runbooks/RELEASE.md)

--- a/docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md
+++ b/docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md
@@ -1,0 +1,31 @@
+# NEOVIM_ROADMAP_ALIGNMENT.md
+
+Reference roadmap: https://neovim.io/roadmap/
+
+## Scope
+This note defines how Jig aligns with upstream Neovim roadmap changes without forcing premature migrations.
+
+## Roadmap items affecting Jig
+1. `vim.pack` (Neovim 0.12 package-management surface)
+2. `vim.async` (Neovim 0.13 async/task primitives)
+3. UI/event evolution (cmdline/ext-message/event surfaces and related API refinements)
+
+## Adopt later
+- `vim.pack`: evaluate as optional backend after parity tests confirm lockfile/install/rollback guarantees remain deterministic.
+- `vim.async`: evaluate for internal task orchestration only after cancellation/error semantics match current safety gates.
+- UI/event additions: adopt only when cmdline stability can be proven with existing harness checks.
+
+## Abstract now
+- Keep plugin lifecycle behind Jig command surface (`:JigPlugin*`) and state files rather than hard-coding one backend assumption.
+- Keep command execution behind `jig.tools.system` wrapper so async substrate can change without user-facing behavior drift.
+- Keep workbench orchestration behind `jig.workbench` module with explicit role/state metadata for deterministic testing.
+
+## Intentionally not chasing
+- No roadmap-item adoption solely for trend alignment.
+- No migration that weakens startup invariants (`no auto-install`, `no startup network mutation`).
+- No mandatory UI overlays that bypass native cmdline path.
+
+## Falsifiable compatibility checks
+- If backend migration is introduced, existing restore/rollback tests must pass unchanged.
+- If async substrate migration is introduced, timeout/cancellation/failure-isolation tests must remain deterministic.
+- If UI primitives change, cmdline open/close and workbench harnesses must remain green in required lanes.

--- a/docs/workbench.jig.nvim.md
+++ b/docs/workbench.jig.nvim.md
@@ -1,0 +1,117 @@
+# workbench.jig.nvim.md
+
+Canonical help: `:help jig-workbench`
+
+## Scope
+Workbench Mode adds one explicit command-first session assembler for daily dogfooding:
+- `:JigWorkbench [dev|review|agent|minimal]`
+- `:JigWorkbenchReset`
+- `:JigWorkbenchHelp`
+  - opens `:help jig-workbench`; if help tags are unavailable in current runtime path, falls back to `:JigDocs`.
+
+Default startup behavior remains unchanged:
+- no startup auto-install/update
+- no startup implicit network mutation
+- no `jig-safe` optional-layer exposure
+
+## Research Log (Explore phase)
+- Date: 2026-02-27
+- Primary roadmap source: https://neovim.io/roadmap/
+- Adjacent workflow baselines:
+  - Helix docs and architecture pages: https://helix-editor.com/
+  - Kakoune design notes: https://github.com/mawww/kakoune/wiki/Why-Kakoune
+  - tmux workflow primitives: https://github.com/tmux/tmux/wiki and https://github.com/tmux/tmux/wiki/Getting-Started
+- Optional local-model ecosystem references (non-blocking, no required CI gates):
+  - Ollama OpenAI compatibility: https://docs.ollama.com/openai
+  - Claude Code gateway controls: https://docs.anthropic.com/en/docs/claude-code/llm-gateway
+  - Codex provider configuration and local endpoint constraints:
+    - https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/config.rs
+    - https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/model_provider_info.rs
+    - https://github.com/openai/codex/issues/1734
+    - https://github.com/openai/codex/issues/7152
+
+## Top 5 Daily Loops
+
+### Loop 1: Coding (feature implementation)
+Step-by-step flow:
+1. Run `:JigWorkbench dev`.
+2. Use left navigation pane to pick working files.
+3. Edit in center pane.
+4. Run local shell/test command in bottom terminal.
+5. Jump diagnostics/navigation with `:JigDiagnostics` and `:JigSymbols`.
+
+### Loop 2: Review (diff/change scan)
+Step-by-step flow:
+1. Run `:JigWorkbench review`.
+2. Inspect left git-change surface.
+3. Open changed files in center pane.
+4. Run targeted validation commands in terminal.
+5. Record repro/support data with `:JigVersion`.
+
+### Loop 3: Run tests and terminal tasks
+Step-by-step flow:
+1. Run `:JigWorkbench dev` or `:JigWorkbench minimal`.
+2. Keep center pane on failing file/test.
+3. Run test/lint commands in terminal pane (when present).
+4. Reset workbench with `:JigWorkbenchReset` when window state drifts.
+
+### Loop 4: Incident triage and recovery
+Step-by-step flow:
+1. Run `:JigWorkbench minimal`.
+2. Use deterministic docs path: `:JigWorkbenchHelp`, `:JigRepro`, `:JigHealth`.
+3. Switch to `NVIM_APPNAME=jig-safe` if optional layers are suspect.
+4. Collect support bundle (`:JigVersion`, `:checkhealth jig`) before issue filing.
+
+### Loop 5: Agent-assisted patch review
+Step-by-step flow:
+1. Enable agent module explicitly (`vim.g.jig_agent = { enabled = true }`).
+2. Run `:JigWorkbench agent`.
+3. Use right queue panel to inspect pending approvals/session counts.
+4. Use explicit review commands (`:JigAgentApprovals`, `:JigPatchSessions`, `:JigPatchReview`).
+5. Keep edits transactional; no direct write bypass.
+
+## Loop-to-Layout Mapping
+| Loop | Minimum components |
+|---|---|
+| 1 | left navigation + center main + bottom terminal |
+| 2 | left git-change navigation + center main + bottom terminal |
+| 3 | center main + optional terminal (preset dependent) |
+| 4 | center main + deterministic command/docs surfaces |
+| 5 | left navigation + center main + bottom terminal + right approvals panel (agent enabled only) |
+
+## Component Assembly and Headless Oracles
+| Component | Jig assembly (primitives) | Headless oracle |
+|---|---|---|
+| Navigation pane | `jig.nav.root` + `jig.nav.fallback` + workbench scratch window | one `jig_workbench_role=nav` window; buffer lines include `:JigFiles`/`:JigGitChanges` |
+| Main editing pane | existing active window retained as `main` role | one `jig_workbench_role=main` window remains valid |
+| Terminal pane | `jig.tools.terminal.open({ scope = \"root\" })` | one `jig_workbench_role=term` window when preset requires terminal |
+| Agent queue pane | `jig.agent.approvals` + `jig.agent.patch` report lines | one `jig_workbench_role=agent` window only in agent preset with agent enabled |
+| Preset/idempotence state | `vim.g.jig_workbench_last` structured table | role counts stable across repeated `:JigWorkbench` invocation |
+
+## Disconfirming Constraints and Mitigations
+- Constraint: forced split re-layout can interrupt a running terminal workflow.
+  - Mitigation: keep reset explicit (`:JigWorkbenchReset`), keep presets small, and preserve center window buffer.
+- Constraint: users may interpret workbench as “automatic IDE intelligence” and miss explicit safety boundaries.
+  - Mitigation: keep all actions command-first and observable; no hidden network/task startup.
+- Constraint: agent preset can feel incomplete when agent module is disabled.
+  - Mitigation: agent preset degrades explicitly (no right panel) with visible message and deterministic command hints.
+
+## First 10 Minutes (Dogfooding Path)
+1. Open project and run `:JigWorkbench dev`.
+2. Edit code in center pane, navigate with left pane.
+3. Execute a local command in bottom pane (`tests/run_harness.lua` subset or project tests).
+4. Run `:JigWorkbench review` before commit.
+5. If agent module is explicitly enabled, run `:JigWorkbench agent` for queue/patch review.
+6. If state drifts, run `:JigWorkbenchReset` and re-run preset.
+
+## Non-Goals
+- No startup automation of package/tool installs.
+- No mandatory UI overlay for cmdline.
+- No required LLM or premium API integration.
+
+## Verification
+```bash
+nvim --headless -u NONE -l scripts/workbench/check_research_done.lua
+tests/workbench/run_harness.sh
+NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbench")==0)' '+qa'
+```

--- a/lua/jig/core/docs.lua
+++ b/lua/jig/core/docs.lua
@@ -13,6 +13,7 @@ local function docs_entries()
     { label = "Install", help = "jig-install" },
     { label = "Configuration", help = "jig-configuration" },
     { label = "Commands", help = "jig-commands" },
+    { label = "Workbench", help = "jig-workbench" },
     { label = "Keymaps", help = "jig-keymaps" },
     { label = "Troubleshooting", help = "jig-troubleshooting" },
     { label = "Migration", help = "jig-migration" },
@@ -43,6 +44,7 @@ local function render_docs_lines(entries)
 
   lines[#lines + 1] = ""
   lines[#lines + 1] = "Recovery shortcuts:"
+  lines[#lines + 1] = "  - :JigWorkbench dev"
   lines[#lines + 1] = "  - :JigRepro"
   lines[#lines + 1] = "  - :JigBisectGuide"
   lines[#lines + 1] = "  - NVIM_APPNAME=jig-safe nvim"

--- a/lua/jig/init.lua
+++ b/lua/jig/init.lua
@@ -23,6 +23,7 @@ end
 require("jig.lsp").setup()
 require("jig.nav").setup()
 require("jig.tools").setup()
+require("jig.workbench").setup()
 
 local user_agent = type(vim.g.jig_agent) == "table" and vim.g.jig_agent or {}
 if user_agent.enabled == true then

--- a/lua/jig/tests/docs/harness.lua
+++ b/lua/jig/tests/docs/harness.lua
@@ -141,6 +141,7 @@ local function command_cross_ref_ok()
 
   local index = read_or_empty(repo_root() .. "/docs/index.jig.nvim.md")
   assert(index:find(":help jig%-keymaps", 1, false) ~= nil, "index missing jig-keymaps link")
+  assert(index:find(":help jig%-workbench", 1, false) ~= nil, "index missing jig-workbench link")
 
   return {
     commands = #entries,
@@ -153,6 +154,7 @@ local function required_vimdoc_ok()
     "jig",
     "jig-install",
     "jig-configuration",
+    "jig-workbench",
     "jig-keymaps",
     "jig-troubleshooting",
     "jig-migration",
@@ -171,6 +173,7 @@ local function required_vimdoc_ok()
     "doc/jig.txt",
     "doc/jig-install.txt",
     "doc/jig-configuration.txt",
+    "doc/jig-workbench.txt",
     "doc/jig-keymaps.txt",
     "doc/jig-troubleshooting.txt",
     "doc/jig-migration.txt",
@@ -265,6 +268,28 @@ local function repro_template_ok()
   for _, path in ipairs(files) do
     assert(vim.fn.filereadable(path) == 1, "missing repro template file: " .. path)
   end
+
+  return {
+    files = #files,
+  }
+end
+
+local function workbench_docs_present_ok()
+  local root = repo_root()
+  local files = {
+    root .. "/docs/workbench.jig.nvim.md",
+    root .. "/docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md",
+    root .. "/doc/jig-workbench.txt",
+  }
+
+  for _, path in ipairs(files) do
+    assert(vim.fn.filereadable(path) == 1, "missing workbench docs file: " .. path)
+  end
+
+  local checker_ok, checker = pcall(require, "jig.workbench.research_check")
+  assert(checker_ok and type(checker.run) == "function", "missing workbench research checker")
+  local ok, report = checker.run({ root = root })
+  assert(ok == true, "workbench research gate failed: " .. table.concat(report.errors or {}, ", "))
 
   return {
     files = #files,
@@ -490,6 +515,10 @@ local cases = {
   {
     id = "repro-template-present",
     run = repro_template_ok,
+  },
+  {
+    id = "workbench-doc-research-gate",
+    run = workbench_docs_present_ok,
   },
   {
     id = "runbooks-present",

--- a/lua/jig/tests/workbench/harness.lua
+++ b/lua/jig/tests/workbench/harness.lua
@@ -1,0 +1,258 @@
+local fabric = require("jig.tests.fabric")
+local brand = require("jig.core.brand")
+local icons = require("jig.ui.icons")
+local workbench = require("jig.workbench")
+
+local M = {}
+
+local function repo_root()
+  if type(_G.__jig_repo_root) == "string" and _G.__jig_repo_root ~= "" then
+    return _G.__jig_repo_root
+  end
+  local source = debug.getinfo(1, "S").source:sub(2)
+  return vim.fn.fnamemodify(source, ":p:h:h:h:h:h")
+end
+
+local function snapshot_path(opts)
+  return fabric.snapshot_path(
+    opts,
+    vim.fn.stdpath("state") .. "/jig/workbench-harness-snapshot.json"
+  )
+end
+
+local function role_counts()
+  local out = {
+    main = 0,
+    nav = 0,
+    term = 0,
+    agent = 0,
+  }
+
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local bufnr = vim.api.nvim_win_get_buf(win)
+    local role = tostring(vim.b[bufnr].jig_workbench_role or "")
+    if out[role] ~= nil then
+      out[role] = out[role] + 1
+    end
+  end
+
+  return out
+end
+
+local function nav_lines(state)
+  if
+    type(state) ~= "table"
+    or type(state.windows) ~= "table"
+    or state.windows.nav == nil
+    or not vim.api.nvim_win_is_valid(state.windows.nav)
+  then
+    return {}
+  end
+  local bufnr = vim.api.nvim_win_get_buf(state.windows.nav)
+  return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
+local function safe_env()
+  local env = vim.fn.environ()
+  env.NVIM_APPNAME = "jig-safe"
+  return env
+end
+
+local function run_safe_assertions()
+  local root = repo_root()
+  local result = vim
+    .system({
+      "nvim",
+      "--headless",
+      "-u",
+      root .. "/init.lua",
+      "+lua assert(vim.fn.exists(':JigWorkbench')==0)",
+      "+lua assert(vim.fn.exists(':JigWorkbenchReset')==0)",
+      "+lua assert(vim.fn.exists(':JigWorkbenchHelp')==0)",
+      "+lua assert(package.loaded['jig.workbench']==nil)",
+      "+qa",
+    }, {
+      env = safe_env(),
+      text = true,
+    })
+    :wait(10000)
+
+  assert(
+    result and result.code == 0,
+    (result and result.stderr or "") .. (result and result.stdout or "")
+  )
+  return { code = result.code }
+end
+
+local cases = {
+  {
+    id = "research-done-r1-r5-gate",
+    run = function()
+      local checker = require("jig.workbench.research_check")
+      local ok, report = checker.run({ root = repo_root() })
+      assert(ok == true, "research gate failed: " .. table.concat(report.errors or {}, ", "))
+      return true, {
+        checks = report.checks,
+      }
+    end,
+  },
+  {
+    id = "default-command-surface",
+    run = function()
+      assert(vim.fn.exists(":JigWorkbench") == 2, "JigWorkbench command missing")
+      assert(vim.fn.exists(":JigWorkbenchReset") == 2, "JigWorkbenchReset command missing")
+      assert(vim.fn.exists(":JigWorkbenchHelp") == 2, "JigWorkbenchHelp command missing")
+      return true, {
+        commands = 3,
+      }
+    end,
+  },
+  {
+    id = "workbench-help-command-surface",
+    run = function()
+      local ok, err = pcall(vim.cmd, brand.command("WorkbenchHelp"))
+      assert(ok == true, "workbench help command failed: " .. tostring(err))
+
+      local marker = type(vim.g.jig_workbench_help_last) == "table"
+          and vim.g.jig_workbench_help_last
+        or {}
+      local is_help = marker.mode == "help"
+      local is_docs_fallback = marker.mode == "docs_index_fallback"
+      assert(is_help or is_docs_fallback, "workbench help marker missing")
+      return true, {
+        mode = marker.mode,
+        docs_mode = marker.docs_mode,
+      }
+    end,
+  },
+  {
+    id = "dev-preset-idempotent-layout",
+    run = function()
+      assert(icons.set_mode("ascii"), "failed to set ascii icon mode")
+      local ok, state = workbench._ensure_layout_for_test("dev")
+      assert(ok == true, "workbench dev preset failed")
+      assert(state.operations.networkish == false, "network-ish command detected in dev preset")
+
+      local first = role_counts()
+      assert(first.nav == 1, "dev preset must create one nav pane")
+      assert(first.term == 1, "dev preset must create one terminal pane")
+      assert(first.agent == 0, "dev preset must not create agent pane")
+      assert(first.main >= 1, "dev preset must keep main pane")
+
+      local nav = nav_lines(state)
+      for _, line in ipairs(nav) do
+        assert(icons.ascii_only(line), "ascii fallback violated in nav line: " .. tostring(line))
+      end
+
+      local ok2, state2 = workbench._ensure_layout_for_test("dev")
+      assert(ok2 == true, "second dev preset invocation failed")
+      assert(state2.operations.networkish == false, "network-ish command on second run")
+      local second = role_counts()
+      assert(vim.deep_equal(first, second), "layout did not converge on second run")
+
+      local cmdline_ok = require("jig.ui.cmdline").open_close_check()
+      assert(cmdline_ok == true, "cmdline open/close regression after workbench")
+
+      return true, {
+        first = first,
+        second = second,
+      }
+    end,
+  },
+  {
+    id = "review-preset-git-surface",
+    run = function()
+      local ok, state = workbench._ensure_layout_for_test("review")
+      assert(ok == true, "workbench review preset failed")
+      assert(state.operations.networkish == false, "network-ish command detected in review preset")
+      assert(state.role_counts.nav == 1, "review preset nav pane missing")
+      assert(state.role_counts.term == 1, "review preset terminal pane missing")
+
+      local lines = nav_lines(state)
+      local joined = table.concat(lines, "\n")
+      assert(joined:find("JigGitChanges", 1, true) ~= nil, "review nav missing git entrypoint")
+
+      return true, {
+        nav_lines = #lines,
+      }
+    end,
+  },
+  {
+    id = "minimal-preset-no-terminal",
+    run = function()
+      local ok, state = workbench._ensure_layout_for_test("minimal")
+      assert(ok == true, "workbench minimal preset failed")
+      assert(state.role_counts.nav == 1, "minimal preset nav pane missing")
+      assert(state.role_counts.term == 0, "minimal preset must not create terminal")
+      assert(state.role_counts.agent == 0, "minimal preset must not create agent pane")
+      return true, {
+        role_counts = state.role_counts,
+      }
+    end,
+  },
+  {
+    id = "agent-preset-disabled-fallback",
+    run = function()
+      local ok, state = workbench._ensure_layout_for_test("agent")
+      assert(ok == true, "workbench agent preset failed")
+      assert(state.agent_state == "skipped_agent_disabled", "agent-disabled fallback mismatch")
+      assert(state.role_counts.agent == 0, "agent pane should not render when module disabled")
+      return true, {
+        agent_state = state.agent_state,
+      }
+    end,
+  },
+  {
+    id = "agent-preset-enabled-panel",
+    run = function()
+      vim.g.jig_agent = { enabled = true }
+      local agent_status = require("jig.agent").setup()
+      assert(agent_status.enabled == true, "agent setup failed for workbench harness")
+
+      local ok, state = workbench._ensure_layout_for_test("agent")
+      assert(ok == true, "workbench agent preset with agent enabled failed")
+      assert(state.agent_state == "enabled", "agent pane should be enabled")
+      assert(state.role_counts.agent == 1, "agent pane should render once")
+
+      local win = state.windows.agent
+      assert(win and vim.api.nvim_win_is_valid(win), "agent pane window invalid")
+      local bufnr = vim.api.nvim_win_get_buf(win)
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local joined = table.concat(lines, "\n")
+      assert(
+        joined:find("JigAgentApprovals", 1, true) ~= nil,
+        "agent pane missing approvals entrypoint"
+      )
+      assert(
+        joined:find("JigPatchReview", 1, true) ~= nil,
+        "agent pane missing patch review entrypoint"
+      )
+
+      return true, {
+        agent_lines = #lines,
+      }
+    end,
+  },
+  {
+    id = "safe-profile-isolation",
+    run = function()
+      local payload = run_safe_assertions()
+      return true, payload
+    end,
+  },
+}
+
+function M.run(opts)
+  local report = fabric.run_cases(cases, {
+    harness = "headless-child-workbench",
+  })
+
+  local path = snapshot_path(opts)
+  fabric.finalize(report, {
+    snapshot_path = path,
+    fail_label = "workbench harness",
+  })
+  print("workbench-harness snapshot written: " .. path)
+end
+
+return M

--- a/lua/jig/tools/terminal.lua
+++ b/lua/jig/tools/terminal.lua
@@ -108,6 +108,7 @@ function M.open(opts)
 
   vim.cmd("botright split")
   local win = vim.api.nvim_get_current_win()
+  vim.cmd("enew")
   local bufnr = vim.api.nvim_get_current_buf()
 
   vim.bo[bufnr].buflisted = false

--- a/lua/jig/workbench/config.lua
+++ b/lua/jig/workbench/config.lua
@@ -1,0 +1,66 @@
+local M = {}
+
+M.defaults = {
+  enabled = true,
+  nav_width = 36,
+  term_height = 12,
+  agent_width = 44,
+  nav_cap = 40,
+  presets = {
+    dev = {
+      nav_source = "files",
+      terminal = true,
+      agent_panel = false,
+    },
+    review = {
+      nav_source = "git_changes",
+      terminal = true,
+      agent_panel = false,
+    },
+    agent = {
+      nav_source = "files",
+      terminal = true,
+      agent_panel = true,
+    },
+    minimal = {
+      nav_source = "files",
+      terminal = false,
+      agent_panel = false,
+    },
+  },
+}
+
+function M.get()
+  local cfg = vim.deepcopy(M.defaults)
+  if type(vim.g.jig_workbench) == "table" then
+    cfg = vim.tbl_deep_extend("force", cfg, vim.g.jig_workbench)
+  end
+  return cfg
+end
+
+function M.resolve_preset(name)
+  local cfg = M.get()
+  local key = tostring(name or ""):lower()
+  if key == "" then
+    key = "dev"
+  end
+
+  local preset = cfg.presets[key]
+  if type(preset) ~= "table" then
+    return nil, key, cfg
+  end
+
+  return vim.tbl_deep_extend("force", {}, preset), key, cfg
+end
+
+function M.preset_names()
+  local cfg = M.get()
+  local names = {}
+  for key, _ in pairs(cfg.presets or {}) do
+    names[#names + 1] = key
+  end
+  table.sort(names)
+  return names
+end
+
+return M

--- a/lua/jig/workbench/init.lua
+++ b/lua/jig/workbench/init.lua
@@ -1,0 +1,622 @@
+local brand = require("jig.core.brand")
+local config = require("jig.workbench.config")
+local icons = require("jig.ui.icons")
+local nav_config = require("jig.nav.config")
+local nav_fallback = require("jig.nav.fallback")
+local nav_root = require("jig.nav.root")
+local terminal = require("jig.tools.terminal")
+
+local M = {}
+
+local commands_registered = false
+
+local function in_ui()
+  return #vim.api.nvim_list_uis() > 0
+end
+
+local function workspace_root()
+  local resolved = nav_root.resolve()
+  if type(resolved) == "table" and type(resolved.root) == "string" and resolved.root ~= "" then
+    return resolved.root
+  end
+  return vim.uv.cwd()
+end
+
+local function is_workbench_role(role)
+  return role == "nav" or role == "term" or role == "agent"
+end
+
+local function role_for_buf(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return ""
+  end
+  return tostring(vim.b[bufnr].jig_workbench_role or "")
+end
+
+local function set_role(bufnr, role)
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    vim.b[bufnr].jig_workbench_role = role
+  end
+end
+
+local function list_tab_windows()
+  return vim.api.nvim_tabpage_list_wins(0)
+end
+
+local function role_windows()
+  local out = {
+    main = {},
+    nav = {},
+    term = {},
+    agent = {},
+    other = {},
+  }
+
+  for _, win in ipairs(list_tab_windows()) do
+    if vim.api.nvim_win_is_valid(win) then
+      local role = role_for_buf(vim.api.nvim_win_get_buf(win))
+      if out[role] ~= nil then
+        out[role][#out[role] + 1] = win
+      else
+        out.other[#out.other + 1] = win
+      end
+    end
+  end
+
+  return out
+end
+
+local function pick_main_window()
+  local roles = role_windows()
+  if #roles.main > 0 and vim.api.nvim_win_is_valid(roles.main[1]) then
+    return roles.main[1]
+  end
+
+  for _, win in ipairs(list_tab_windows()) do
+    if vim.api.nvim_win_is_valid(win) then
+      local role = role_for_buf(vim.api.nvim_win_get_buf(win))
+      if not is_workbench_role(role) then
+        return win
+      end
+    end
+  end
+
+  local current = vim.api.nvim_get_current_win()
+  if vim.api.nvim_win_is_valid(current) then
+    return current
+  end
+
+  return list_tab_windows()[1]
+end
+
+local function close_window(win)
+  if not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+  pcall(vim.api.nvim_win_close, win, true)
+end
+
+local function close_role_windows(role)
+  local roles = role_windows()
+  for _, win in ipairs(roles[role] or {}) do
+    close_window(win)
+  end
+end
+
+local function close_workbench_roles()
+  close_role_windows("nav")
+  close_role_windows("term")
+  close_role_windows("agent")
+end
+
+local function with_current_win(win, fn)
+  local previous = vim.api.nvim_get_current_win()
+  if vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+  end
+  local ok, result1, result2, result3 = pcall(fn)
+  if vim.api.nvim_win_is_valid(previous) then
+    vim.api.nvim_set_current_win(previous)
+  end
+  if not ok then
+    error(result1)
+  end
+  return result1, result2, result3
+end
+
+local function make_scratch_buffer(name, lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[bufnr].buftype = "nofile"
+  vim.bo[bufnr].bufhidden = "wipe"
+  vim.bo[bufnr].swapfile = false
+  vim.bo[bufnr].modifiable = true
+  vim.bo[bufnr].filetype = "jigworkbench"
+  vim.api.nvim_buf_set_name(bufnr, name)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].modifiable = false
+  return bufnr
+end
+
+local function split_lines(text)
+  if type(text) ~= "string" or text == "" then
+    return {}
+  end
+  return vim.split(text, "\n", { plain = true, trimempty = true })
+end
+
+local function command_token(argv)
+  local first = tostring((argv and argv[1]) or "")
+  return first:lower()
+end
+
+local function networkish_argv(argv)
+  local token = command_token(argv)
+  local risky = {
+    curl = true,
+    wget = true,
+    http = true,
+    https = true,
+    npm = true,
+    cargo = true,
+    pip = true,
+    pnpm = true,
+    yarn = true,
+  }
+  if risky[token] then
+    return true
+  end
+
+  if token == "git" then
+    local sub = tostring((argv and argv[4]) or (argv and argv[2]) or ""):lower()
+    local git_network = {
+      clone = true,
+      fetch = true,
+      pull = true,
+      push = true,
+      remote = true,
+      ls_remote = true,
+      lsremote = true,
+    }
+    return git_network[sub] == true
+  end
+
+  return false
+end
+
+local function git_status_lines(root, operations, cap)
+  local system = require("jig.tools.system")
+  local argv = { "git", "-C", root, "status", "--short" }
+  operations[#operations + 1] = argv
+
+  local result = system.run_sync(argv, {
+    timeout_ms = 2000,
+    actor = "user",
+    origin = "jig.workbench.nav",
+  })
+
+  if result.ok ~= true then
+    return {
+      string.format("%s git status unavailable", icons.get("warning")),
+      "hint: use :JigGitChanges for interactive path once git repo is available.",
+    },
+      false
+  end
+
+  local rows = {}
+  for _, line in ipairs(split_lines(result.stdout)) do
+    rows[#rows + 1] = line
+    if #rows >= cap then
+      break
+    end
+  end
+
+  if #rows == 0 then
+    rows = { string.format("%s clean working tree", icons.get("health")) }
+  end
+
+  return rows, true
+end
+
+local function files_lines(root, cap)
+  local nav_cfg = nav_config.get()
+  local items = nav_fallback.list_files(root, {
+    cap = cap,
+    ignore_globs = nav_cfg.ignore_globs,
+  })
+
+  local rows = {}
+  for _, item in ipairs(items) do
+    rows[#rows + 1] = tostring(item.label)
+    if #rows >= cap then
+      break
+    end
+  end
+
+  if #rows == 0 then
+    rows = { string.format("%s no files found", icons.get("warning")) }
+  end
+
+  return rows
+end
+
+local function nav_lines(preset_name, preset, root, cfg, operations)
+  local title = preset.nav_source == "git_changes" and "Git changes" or "Files"
+  local lines = {
+    string.format("%s Jig Workbench (%s)", icons.get("action"), preset_name),
+    string.rep("=", 46),
+    string.format("root: %s", root),
+    string.format("source: %s", title),
+    "",
+    "entrypoints:",
+    "  :JigFiles",
+    "  :JigGitChanges",
+    "  :JigDiagnostics",
+    "  :JigTerm root",
+    "  :JigWorkbenchReset",
+    "",
+  }
+
+  local content
+  if preset.nav_source == "git_changes" then
+    content = git_status_lines(root, operations, cfg.nav_cap)
+  else
+    content = files_lines(root, cfg.nav_cap)
+  end
+
+  if type(content) == "table" and type(content[1]) == "table" then
+    content = content[1]
+  end
+
+  lines[#lines + 1] = "items:"
+  for _, row in ipairs(content) do
+    lines[#lines + 1] = "  " .. tostring(row)
+  end
+
+  return lines
+end
+
+local function agent_panel_lines(root)
+  local approvals = require("jig.agent.approvals")
+  local patch = require("jig.agent.patch")
+  local pending = approvals.list({ status = "pending" })
+  local sessions = patch.list()
+
+  local lines = {
+    string.format("%s Agent Queue", icons.get("warning")),
+    string.rep("=", 32),
+    string.format("root: %s", root),
+    string.format("pending approvals: %d", #pending),
+    string.format("patch sessions: %d", #sessions),
+    "",
+    "entrypoints:",
+    "  :JigAgentApprovals",
+    "  :JigPatchSessions",
+    "  :JigPatchReview <session_id>",
+    "  :JigAgentContext",
+    "",
+  }
+
+  if #pending > 0 then
+    lines[#lines + 1] = "pending:"
+    for _, item in ipairs(pending) do
+      lines[#lines + 1] = string.format(
+        "  - %s %s %s",
+        tostring(item.id),
+        tostring(item.subject.action_class),
+        tostring(item.subject.target)
+      )
+    end
+    lines[#lines + 1] = ""
+  end
+
+  if #sessions > 0 then
+    lines[#lines + 1] = "patch sessions:"
+    for _, session in ipairs(sessions) do
+      lines[#lines + 1] = string.format(
+        "  - %s status=%s files=%d",
+        tostring(session.id),
+        tostring(session.status),
+        #(session.files or {})
+      )
+    end
+  end
+
+  return lines
+end
+
+local function open_nav_window(main_win, lines, width)
+  return with_current_win(main_win, function()
+    vim.cmd("topleft vsplit")
+    local win = vim.api.nvim_get_current_win()
+    if width and width > 20 then
+      pcall(vim.api.nvim_win_set_width, win, math.floor(width))
+    end
+
+    local bufnr = make_scratch_buffer("jig://workbench/nav", lines)
+    vim.api.nvim_win_set_buf(win, bufnr)
+    set_role(bufnr, "nav")
+    return {
+      win = win,
+      bufnr = bufnr,
+    }
+  end)
+end
+
+local function open_agent_window(main_win, lines, width)
+  return with_current_win(main_win, function()
+    vim.cmd("botright vsplit")
+    local win = vim.api.nvim_get_current_win()
+    if width and width > 20 then
+      pcall(vim.api.nvim_win_set_width, win, math.floor(width))
+    end
+
+    local bufnr = make_scratch_buffer("jig://workbench/agent", lines)
+    vim.api.nvim_win_set_buf(win, bufnr)
+    set_role(bufnr, "agent")
+    return {
+      win = win,
+      bufnr = bufnr,
+    }
+  end)
+end
+
+local function open_term_window(main_win, height)
+  local ok, state = with_current_win(main_win, function()
+    return terminal.open({ scope = "root" })
+  end)
+  if ok ~= true then
+    return false, state
+  end
+
+  if type(state) == "table" and state.win and vim.api.nvim_win_is_valid(state.win) then
+    if height and height > 4 then
+      pcall(vim.api.nvim_win_set_height, state.win, math.floor(height))
+    end
+    set_role(state.bufnr, "term")
+  end
+
+  return true, state
+end
+
+local function agent_enabled()
+  if vim.fn.exists(":" .. brand.command("AgentApprovals")) ~= 2 then
+    return false
+  end
+  if vim.fn.exists(":" .. brand.command("PatchReview")) ~= 2 then
+    return false
+  end
+  return true
+end
+
+local function ensure_main_role(main_win)
+  if not vim.api.nvim_win_is_valid(main_win) then
+    return nil
+  end
+  local bufnr = vim.api.nvim_win_get_buf(main_win)
+  set_role(bufnr, "main")
+  return bufnr
+end
+
+local function ensure_layout(preset_name)
+  local preset, normalized, cfg = config.resolve_preset(preset_name)
+  if preset == nil then
+    return false, string.format("unknown preset: %s", normalized)
+  end
+
+  local main_win = pick_main_window()
+  if not main_win or not vim.api.nvim_win_is_valid(main_win) then
+    return false, "no active window available"
+  end
+
+  ensure_main_role(main_win)
+  close_workbench_roles()
+  if not vim.api.nvim_win_is_valid(main_win) then
+    main_win = pick_main_window()
+    ensure_main_role(main_win)
+  end
+
+  local root = workspace_root()
+  local operations = {}
+
+  local nav =
+    open_nav_window(main_win, nav_lines(normalized, preset, root, cfg, operations), cfg.nav_width)
+
+  local term = nil
+  if preset.terminal == true then
+    local ok_term, term_state_or_err = open_term_window(main_win, cfg.term_height)
+    if ok_term then
+      term = term_state_or_err
+    else
+      vim.notify(
+        "JigWorkbench terminal failed: " .. tostring(term_state_or_err),
+        vim.log.levels.WARN
+      )
+    end
+  end
+
+  local agent = nil
+  local agent_state = "disabled"
+  if preset.agent_panel == true then
+    if agent_enabled() then
+      agent = open_agent_window(main_win, agent_panel_lines(root), cfg.agent_width)
+      agent_state = "enabled"
+    else
+      agent_state = "skipped_agent_disabled"
+      vim.notify(
+        "JigWorkbench agent preset: agent module is disabled; right panel skipped.",
+        vim.log.levels.INFO
+      )
+    end
+  end
+
+  if vim.api.nvim_win_is_valid(main_win) then
+    vim.api.nvim_set_current_win(main_win)
+  end
+
+  local networkish = false
+  for _, argv in ipairs(operations) do
+    if networkish_argv(argv) then
+      networkish = true
+      break
+    end
+  end
+
+  local roles = role_windows()
+  local state = {
+    preset = normalized,
+    root = root,
+    agent_state = agent_state,
+    windows = {
+      main = main_win,
+      nav = nav and nav.win or nil,
+      term = term and term.win or nil,
+      agent = agent and agent.win or nil,
+    },
+    role_counts = {
+      main = #roles.main,
+      nav = #roles.nav,
+      term = #roles.term,
+      agent = #roles.agent,
+    },
+    operations = {
+      argv = operations,
+      networkish = networkish,
+    },
+    icon_mode = icons.mode(),
+  }
+
+  vim.g.jig_workbench_last = state
+  vim.g.jig_workbench_last_preset = normalized
+
+  return true, state
+end
+
+local function reset_layout()
+  close_workbench_roles()
+  vim.g.jig_workbench_last = nil
+  vim.g.jig_workbench_last_preset = nil
+  return {
+    reset = true,
+    wins = #list_tab_windows(),
+  }
+end
+
+local function cmd_workbench(opts)
+  local ok, state_or_err = ensure_layout(opts.args)
+  if not ok then
+    vim.notify("JigWorkbench failed: " .. tostring(state_or_err), vim.log.levels.ERROR)
+    return
+  end
+
+  if in_ui() then
+    vim.notify(
+      string.format("JigWorkbench preset=%s root=%s", state_or_err.preset, state_or_err.root),
+      vim.log.levels.INFO
+    )
+  end
+end
+
+local function cmd_workbench_reset()
+  local payload = reset_layout()
+  if in_ui() then
+    vim.notify("JigWorkbench reset", vim.log.levels.INFO)
+  else
+    print(vim.inspect(payload))
+  end
+end
+
+local function cmd_workbench_help()
+  local ok = pcall(vim.cmd, "help jig-workbench")
+  if ok then
+    vim.g.jig_workbench_help_last = {
+      mode = "help",
+      tag = "jig-workbench",
+    }
+    return
+  end
+
+  local docs_ok, docs_state = pcall(function()
+    return require("jig.core.docs").open_docs_index({ force_scratch = true })
+  end)
+  if docs_ok then
+    vim.g.jig_workbench_help_last = {
+      mode = "docs_index_fallback",
+      tag = "jig-workbench",
+      docs_mode = type(docs_state) == "table" and docs_state.mode or "unknown",
+    }
+    if not in_ui() then
+      print("JigWorkbenchHelp fallback: docs index")
+    end
+    return
+  end
+
+  vim.notify(
+    "JigWorkbenchHelp unavailable: missing help tag and docs fallback failed.",
+    vim.log.levels.ERROR
+  )
+end
+
+local function create_command(name, callback, opts)
+  if vim.fn.exists(":" .. name) == 2 then
+    return
+  end
+  vim.api.nvim_create_user_command(name, callback, opts or {})
+end
+
+function M.setup()
+  if vim.g.jig_safe_profile then
+    return {
+      enabled = false,
+      reason = "safe_profile",
+    }
+  end
+
+  local cfg = config.get()
+  if cfg.enabled ~= true then
+    return {
+      enabled = false,
+      reason = "disabled",
+    }
+  end
+
+  if commands_registered then
+    return {
+      enabled = true,
+      reason = "already_registered",
+    }
+  end
+
+  create_command(brand.command("Workbench"), cmd_workbench, {
+    nargs = "?",
+    complete = function()
+      return config.preset_names()
+    end,
+    desc = "Assemble an idempotent workbench layout (dev|review|agent|minimal)",
+  })
+
+  create_command(brand.command("WorkbenchReset"), cmd_workbench_reset, {
+    nargs = 0,
+    desc = "Reset workbench layout roles in current tab",
+  })
+
+  create_command(brand.command("WorkbenchHelp"), cmd_workbench_help, {
+    nargs = 0,
+    desc = "Open workbench help topic",
+  })
+
+  commands_registered = true
+  return {
+    enabled = true,
+    reason = "registered",
+  }
+end
+
+function M._ensure_layout_for_test(preset_name)
+  return ensure_layout(preset_name)
+end
+
+function M._reset_for_test()
+  return reset_layout()
+end
+
+return M

--- a/lua/jig/workbench/research_check.lua
+++ b/lua/jig/workbench/research_check.lua
@@ -1,0 +1,102 @@
+local M = {}
+
+local function read(path)
+  if vim.fn.filereadable(path) ~= 1 then
+    return nil
+  end
+  return table.concat(vim.fn.readfile(path), "\n")
+end
+
+local function count_pattern(text, pattern)
+  local total = 0
+  for _ in tostring(text):gmatch(pattern) do
+    total = total + 1
+  end
+  return total
+end
+
+local function contains(text, needle)
+  return tostring(text):find(needle, 1, true) ~= nil
+end
+
+function M.run(opts)
+  opts = opts or {}
+  local root = opts.root or _G.__jig_repo_root or vim.fn.getcwd()
+  local workbench_doc = root .. "/docs/workbench.jig.nvim.md"
+  local alignment_doc = root .. "/docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md"
+
+  local workbench = read(workbench_doc)
+  local alignment = read(alignment_doc)
+  local errors = {}
+
+  if workbench == nil then
+    errors[#errors + 1] = "missing docs/workbench.jig.nvim.md"
+  end
+  if alignment == nil then
+    errors[#errors + 1] = "missing docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md"
+  end
+
+  if #errors > 0 then
+    return false, {
+      errors = errors,
+      checks = {},
+    }
+  end
+
+  local checks = {}
+
+  checks.r1_heading = contains(workbench, "## Top 5 Daily Loops")
+  checks.r1_loop_count = count_pattern(workbench, "### Loop %d:") >= 5
+  checks.r1_step_flow = contains(workbench, "Step-by-step flow")
+
+  checks.r2_layout_heading = contains(workbench, "## Loop-to-Layout Mapping")
+  checks.r2_layout_rows = contains(workbench, "| Loop | Minimum components |")
+    and contains(workbench, "| 1 |")
+    and contains(workbench, "| 5 |")
+
+  checks.r3_component_heading = contains(workbench, "## Component Assembly and Headless Oracles")
+  checks.r3_component_rows = contains(
+    workbench,
+    "| Component | Jig assembly (primitives) | Headless oracle |"
+  ) and contains(workbench, "Navigation pane") and contains(workbench, "Main editing pane") and contains(
+    workbench,
+    "Terminal pane"
+  )
+
+  checks.r4_disconfirm_heading = contains(workbench, "## Disconfirming Constraints and Mitigations")
+  checks.r4_disconfirm_count = count_pattern(workbench, "%- Constraint:") >= 2
+
+  checks.r5_alignment_heading = contains(alignment, "# NEOVIM_ROADMAP_ALIGNMENT.md")
+  checks.r5_vim_pack = contains(alignment, "vim.pack")
+  checks.r5_vim_async = contains(alignment, "vim.async")
+  checks.r5_ui_item = contains(alignment, "UI")
+    or contains(alignment, "events")
+    or contains(alignment, "cmdline")
+  checks.r5_policy_sections = contains(alignment, "Adopt later")
+    and contains(alignment, "Abstract now")
+    and contains(alignment, "Intentionally not chasing")
+
+  checks.sources_neovim = contains(workbench, "https://neovim.io/roadmap/")
+  checks.sources_helix = contains(workbench, "https://helix-editor.com/")
+  checks.sources_kakoune = contains(workbench, "https://github.com/mawww/kakoune")
+    or contains(workbench, "https://kakoune.org/")
+  checks.sources_tmux = contains(workbench, "https://github.com/tmux/tmux/wiki")
+    or contains(workbench, "https://github.com/tmux/tmux")
+  checks.sources_ollama = contains(workbench, "https://docs.ollama.com/openai")
+  checks.sources_claude =
+    contains(workbench, "https://docs.anthropic.com/en/docs/claude-code/llm-gateway")
+  checks.sources_codex = contains(workbench, "https://github.com/openai/codex")
+
+  for name, ok in pairs(checks) do
+    if ok ~= true then
+      errors[#errors + 1] = "failed " .. name
+    end
+  end
+
+  return #errors == 0, {
+    errors = errors,
+    checks = checks,
+  }
+end
+
+return M

--- a/scripts/workbench/check_research_done.lua
+++ b/scripts/workbench/check_research_done.lua
@@ -1,0 +1,22 @@
+local function fail(message)
+  vim.api.nvim_err_writeln(message)
+  vim.cmd("cquit 1")
+end
+
+local root = vim.fn.getcwd()
+_G.__jig_repo_root = root
+package.path = string.format("%s/lua/?.lua;%s/lua/?/init.lua;", root, root) .. package.path
+
+local ok, checker = pcall(require, "jig.workbench.research_check")
+if not ok then
+  fail("failed to load workbench research checker: " .. tostring(checker))
+end
+
+local passed, payload = checker.run({ root = root })
+if not passed then
+  local errors = payload and payload.errors or { "unknown error" }
+  fail("workbench research gate failed:\n - " .. table.concat(errors, "\n - "))
+end
+
+print("workbench research gate passed")
+vim.cmd("qa")

--- a/tests/run_harness.lua
+++ b/tests/run_harness.lua
@@ -66,6 +66,9 @@ local function run_startup_smoke()
   assert(vim.fn.exists(":JigToolchainUpdate") == 2, "JigToolchainUpdate missing")
   assert(vim.fn.exists(":JigToolchainRestore") == 2, "JigToolchainRestore missing")
   assert(vim.fn.exists(":JigToolchainRollback") == 2, "JigToolchainRollback missing")
+  assert(vim.fn.exists(":JigWorkbench") == 2, "JigWorkbench missing")
+  assert(vim.fn.exists(":JigWorkbenchReset") == 2, "JigWorkbenchReset missing")
+  assert(vim.fn.exists(":JigWorkbenchHelp") == 2, "JigWorkbenchHelp missing")
   assert(vim.fn.exists(":JigMcpTrust") == 0, "JigMcpTrust should be absent by default")
   assert(vim.fn.exists(":JigMcpList") == 0, "JigMcpList should be absent by default")
   assert(vim.fn.exists(":JigAgentContext") == 0, "JigAgentContext should be absent by default")
@@ -111,6 +114,9 @@ local function run_startup_smoke()
       join(ROOT, "init.lua"),
       "+lua assert(vim.g.jig_profile=='safe','safe profile expected')",
       "+lua assert(vim.fn.exists(':JigVersion')==2,'JigVersion missing in safe profile')",
+      "+lua assert(vim.fn.exists(':JigWorkbench')==0,'JigWorkbench should be absent in safe profile')",
+      "+lua assert(vim.fn.exists(':JigWorkbenchReset')==0,'JigWorkbenchReset should be absent in safe profile')",
+      "+lua assert(vim.fn.exists(':JigWorkbenchHelp')==0,'JigWorkbenchHelp should be absent in safe profile')",
       "+JigVersion",
       "+qa",
     }, {
@@ -167,6 +173,10 @@ local SUITES = {
   tools = {
     module = "jig.tests.tools.harness",
     snapshot = join(ROOT, "tests/tools/snapshots/latest-headless.json"),
+  },
+  workbench = {
+    module = "jig.tests.workbench.harness",
+    snapshot = join(ROOT, "tests/workbench/snapshots/latest-headless.json"),
   },
   lsp = {
     module = "jig.tests.lsp.harness",

--- a/tests/workbench/run_harness.sh
+++ b/tests/workbench/run_harness.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+nvim --headless -u NONE -l tests/run_harness.lua -- --suite workbench
+
+echo "Workbench harness passed. Snapshot: ${repo_root}/tests/workbench/snapshots/latest-headless.json"

--- a/tests/workbench/snapshots/.gitignore
+++ b/tests/workbench/snapshots/.gitignore
@@ -1,0 +1,1 @@
+latest-headless.json


### PR DESCRIPTION
Closes #53

## Mode
Settle (Explore artifacts are captured in `docs/workbench.jig.nvim.md` and enforced by `scripts/workbench/check_research_done.lua`).

## Why
Jig v0.1.0 is operational but still manual-command-heavy for daily use. This PR adds one explicit, idempotent entrypoint for a repeatable IDE-like session layout while preserving existing safety/repro invariants.

## Scope guard
- WP-closed post-release increment only (no roadmap rewrite / no new WP).
- No startup auto-install/update.
- No startup implicit network behavior.
- `NVIM_APPNAME=jig-safe` keeps optional layer isolation.
- Native cmdline path remains default.
- ASCII icon mode remains legible.

## Research done truth conditions (R1–R5)
- **R1 Top 5 loops**: documented under `docs/workbench.jig.nvim.md#top-5-daily-loops` with step-by-step flows.
- **R2 Loop → minimum UI layout**: `docs/workbench.jig.nvim.md#loop-to-layout-mapping`.
- **R3 Component implementation + headless detection**: `docs/workbench.jig.nvim.md#component-assembly-and-headless-oracles`.
- **R4 Disconfirming constraints + mitigations**: `docs/workbench.jig.nvim.md#disconfirming-constraints-and-mitigations` (>=2 constraints).
- **R5 Neovim roadmap alignment note**: `docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md` (vim.pack, vim.async, UI/events; adopt/abstract/not-chasing policy).
- **Deterministic in-repo gate**: `scripts/workbench/check_research_done.lua` + `lua/jig/workbench/research_check.lua`.

## Deliverables → files
1. Workbench module + command surface (`:JigWorkbench`, `:JigWorkbenchReset`, `:JigWorkbenchHelp`)
   - `lua/jig/workbench/config.lua`
   - `lua/jig/workbench/init.lua`
   - `lua/jig/init.lua`
2. Headless deterministic workbench suite + safe-profile falsifier
   - `lua/jig/tests/workbench/harness.lua`
   - `tests/workbench/run_harness.sh`
   - `tests/run_harness.lua`
3. CI required-lane integration
   - `.github/workflows/ci.yml`
4. Docs/vimdoc/discoverability
   - `docs/workbench.jig.nvim.md`
   - `docs/roadmap/NEOVIM_ROADMAP_ALIGNMENT.md`
   - `doc/jig-workbench.txt`
   - `doc/jig.txt`
   - `docs/index.jig.nvim.md`
   - `docs/commands.jig.nvim.md`
   - `doc/jig-commands.txt`
   - `doc/tags`
   - `lua/jig/core/docs.lua`
5. Research truth-condition checker and docs harness hook
   - `scripts/workbench/check_research_done.lua`
   - `lua/jig/workbench/research_check.lua`
   - `lua/jig/tests/docs/harness.lua`

## Verification commands + output summary
```bash
stylua --check --config-path .stylua.toml $(rg --files lua -g '*.lua')
nvim --headless -u NONE -l tests/run_harness.lua -- --suite startup --suite tools --suite docs --suite scorecard --suite workbench
NVIM_APPNAME=jig-safe nvim --headless -u ./init.lua '+lua assert(vim.fn.exists(":JigWorkbench")==0)' '+qa'
tests/check_hidden_unicode.sh
scripts/wp15/check_research_done.lua
scripts/wp15/check_gaps.lua
```
All commands exit `0`.

Additional smoke:
```bash
nvim --headless -u ./init.lua '+JigWorkbenchHelp' '+qa'
```
Exit `0` (falls back to `:JigDocs` if help tags unavailable in active runtime path).

## Falsifiers checked (with discriminating tests)
1. **Idempotence regression** (`:JigWorkbench` duplicates panes)
   - `workbench` case: `dev-preset-idempotent-layout` (role counts equal on second invocation).
2. **Safe-profile leak** (`jig-safe` exposes workbench commands/module)
   - `workbench` case: `safe-profile-isolation` + explicit command assertion above.
3. **Network side effects via workbench path**
   - `workbench` cases assert `state.operations.networkish == false` for presets.
4. **Docs/research contract drift (R1–R5 not met)**
   - `workbench` case: `research-done-r1-r5-gate` + docs harness case `workbench-doc-research-gate`.

## Residual risks (max 7)
1. `:JigWorkbenchHelp` may use docs-index fallback if runtime help tags are unavailable in the active runtime path.
2. Terminal split behavior can still be impacted by third-party autocmd/plugin local customizations in user environments.
3. Agent preset right panel remains intentionally conditional on explicit agent module enablement (no default enable).
4. Current presets optimize for deterministic baseline; some workflows may require user tuning via `vim.g.jig_workbench`.

## Rollback plan
```bash
git revert 33cd8d9
```
This removes workbench module wiring, CI hooks, and docs additions; existing command-first surfaces remain unchanged.
